### PR TITLE
fix: validate slug before write (empty, whitespace, reserved chars)

### DIFF
--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -5,12 +5,39 @@ import { dirname } from "node:path";
 
 const REQUIRED_FIELDS = ["title", "created", "source"];
 
+/** Characters that are invalid in a slug component */
+const INVALID_SLUG_RE = /[\\:*?"<>|]/;
+
+export function validateSlug(slug: string): string | null {
+  if (!slug || slug.trim() === "") {
+    return "Slug must not be empty";
+  }
+  // Reject slugs that are only slashes or dots
+  if (/^[./\\]+$/.test(slug)) {
+    return `Invalid slug: '${slug}'`;
+  }
+  // Reject OS-reserved characters on Windows / problematic in URLs
+  const parts = slug.split("/");
+  for (const part of parts) {
+    if (!part) return `Invalid slug: empty path segment in '${slug}'`;
+    if (INVALID_SLUG_RE.test(part)) {
+      return `Invalid slug: '${slug}' contains reserved characters (\\:*?"<>|)`;
+    }
+  }
+  return null;
+}
+
 interface WriteResult {
   success: boolean;
   error?: string;
 }
 
 export async function writeCommand(store: CardStore, slug: string, input: string): Promise<WriteResult> {
+  const slugError = validateSlug(slug);
+  if (slugError) {
+    return { success: false, error: slugError };
+  }
+
   const { data, content } = parseFrontmatter(input);
 
   const missing = REQUIRED_FIELDS.filter((f) => !(f in data));

--- a/tests/commands/write.test.ts
+++ b/tests/commands/write.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writeCommand } from "../../src/commands/write.js";
+import { writeCommand, validateSlug } from "../../src/commands/write.js";
 import { CardStore } from "../../src/lib/store.js";
 import { parseFrontmatter } from "../../src/lib/parser.js";
 
@@ -79,5 +79,84 @@ Body.`;
     expect(written).not.toContain("2026-03-18T00:00:00.000Z");
     // Should contain clean YYYY-MM-DD
     expect(written).toContain("created: '2026-03-18'");
+  });
+
+  it("rejects empty slug", async () => {
+    const input = `---
+title: Empty Slug Test
+created: 2026-03-21
+source: test
+---
+body`;
+    const result = await writeCommand(store, "", input);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("empty");
+  });
+
+  it("rejects whitespace-only slug", async () => {
+    const input = `---
+title: Whitespace Slug
+created: 2026-03-21
+source: test
+---
+body`;
+    const result = await writeCommand(store, "   ", input);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects slug with reserved characters", async () => {
+    const input = `---
+title: Reserved Chars
+created: 2026-03-21
+source: test
+---
+body`;
+    const result = await writeCommand(store, "my:card", input);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("reserved");
+  });
+});
+
+describe("validateSlug", () => {
+  it("accepts valid kebab-case slugs", () => {
+    expect(validateSlug("my-card")).toBeNull();
+    expect(validateSlug("my-card-123")).toBeNull();
+  });
+
+  it("accepts valid subdirectory slugs", () => {
+    expect(validateSlug("sub/my-card")).toBeNull();
+    expect(validateSlug("a/b/c")).toBeNull();
+  });
+
+  it("accepts slugs with unicode (e.g. CJK)", () => {
+    // Unicode slugs are allowed but not recommended
+    expect(validateSlug("我的卡片")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(validateSlug("")).not.toBeNull();
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(validateSlug("   ")).not.toBeNull();
+  });
+
+  it("rejects slug of only dots/slashes", () => {
+    expect(validateSlug(".")).not.toBeNull();
+    expect(validateSlug("..")).not.toBeNull();
+    expect(validateSlug("/")).not.toBeNull();
+    expect(validateSlug("./")).not.toBeNull();
+  });
+
+  it("rejects slug with empty path segment", () => {
+    expect(validateSlug("a//b")).not.toBeNull();
+    expect(validateSlug("/foo")).not.toBeNull();
+  });
+
+  it("rejects slug with reserved OS characters", () => {
+    expect(validateSlug("my:card")).not.toBeNull();
+    expect(validateSlug('my"card')).not.toBeNull();
+    expect(validateSlug("my*card")).not.toBeNull();
+    expect(validateSlug("my?card")).not.toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #4

Adds `validateSlug()` to reject empty, whitespace-only, dots-only, empty-segment, and OS-reserved-char slugs. Exports the function for reuse. 88 tests passing.