### PR TITLE
fix: clamp negative --limit to DEFAULT_LIMIT in search command

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -30,7 +30,9 @@ export async function searchCommand(store: CardStore, query: string | undefined,
   }
 
   // With query: search body only (strip frontmatter before matching)
-  const limit = options.limit ?? DEFAULT_LIMIT;
+  const rawLimit = options.limit ?? DEFAULT_LIMIT;
+  // Clamp limit to a safe positive range; 0 returns no results (intentional)
+  const limit = rawLimit < 0 ? DEFAULT_LIMIT : rawLimit;
   const matchedCards: { slug: string; matchLine: string; matchCount: number }[] = [];
 
   for (const card of cards) {

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -88,6 +88,20 @@ When JWT revoke fails, use cache as fallback. See [[jwt-migration]].`
     expect(headings.length).toBe(1);
   });
 
+  it("treats negative limit as default (not slice-from-end)", async () => {
+    // With 2 matching cards and limit=-1, should NOT silently strip the last result
+    // It should fall back to DEFAULT_LIMIT (10), returning all 2 matches
+    const result = await searchCommand(store, "JWT", { limit: -1 });
+    // Should contain all matches (both jwt-migration and caching have 'JWT')
+    expect(result.output).toContain("## jwt-migration");
+    expect(result.output).toContain("## caching");
+  });
+
+  it("returns empty output for limit=0", async () => {
+    const result = await searchCommand(store, "JWT", { limit: 0 });
+    expect(result.output).toBe("");
+  });
+
   it("is case-insensitive", async () => {
     const result = await searchCommand(store, "jwt");
     expect(result.output).toContain("## jwt-migration");


### PR DESCRIPTION
Fixes #6

Negative limit is clamped to DEFAULT_LIMIT instead of being passed to `Array.slice()` which silently corrupts results. Added 2 new tests. 79 tests passing.