### PR TITLE
fix: preserve subdirectory prefix in scanAll slugs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,7 @@ program
       process.stderr.write(result.error! + "\n");
       process.exit(1);
     }
+    process.stdout.write(`Wrote card: ${slug}\n`);
   });
 
 program

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, writeFile, rename, mkdir } from "node:fs/promises";
-import { join, basename, dirname, resolve } from "node:path";
+import { join, basename, dirname, resolve, relative } from "node:path";
 
 interface ScannedCard {
   slug: string;
@@ -40,7 +40,7 @@ export class CardStore {
         await this.walkDir(fullPath, results);
       } else if (entry.name.endsWith(".md")) {
         results.push({
-          slug: basename(entry.name, ".md"),
+          slug: relative(this.cardsDir, fullPath).replace(/\.md$/, ""),
           path: fullPath,
         });
       }
@@ -87,8 +87,8 @@ export class CardStore {
         throw new Error(`Card not found: ${slug}`);
       }
     }
-    await mkdir(this.archiveDir, { recursive: true });
     const dest = join(this.archiveDir, `${slug}.md`);
+    await mkdir(dirname(dest), { recursive: true });
     await rename(path, dest);
     this.invalidateCache();
   }

--- a/tests/commands/read.test.ts
+++ b/tests/commands/read.test.ts
@@ -37,7 +37,7 @@ describe("readCommand", () => {
   it("finds card in subdirectory", async () => {
     await mkdir(join(tmpDir, "cards", "sub"), { recursive: true });
     await writeFile(join(tmpDir, "cards", "sub", "nested.md"), "content");
-    const result = await readCommand(store, "nested");
+    const result = await readCommand(store, "sub/nested");
     expect(result.success).toBe(true);
     expect(result.content).toBe("content");
   });

--- a/tests/lib/store.test.ts
+++ b/tests/lib/store.test.ts
@@ -31,7 +31,7 @@ describe("CardStore", () => {
 
       const files = await store.scanAll();
       const slugs = files.map((f) => f.slug).sort();
-      expect(slugs).toEqual(["a", "b"]);
+      expect(slugs).toEqual(["a", "sub/b"]);
     });
 
     it("returns empty array when no cards", async () => {
@@ -50,7 +50,7 @@ describe("CardStore", () => {
     it("finds card by slug in subdirectory", async () => {
       await mkdir(join(cardsDir, "sub"), { recursive: true });
       await writeFile(join(cardsDir, "sub", "nested.md"), "content");
-      const path = await store.resolve("nested");
+      const path = await store.resolve("sub/nested");
       expect(path).toBe(join(cardsDir, "sub", "nested.md"));
     });
 


### PR DESCRIPTION
Fixes #2

## Problem
`CardStore.scanAll()` used `basename(entry.name, '.md')` as the slug, stripping subdirectory prefixes. Cards at `cards/sub/foo.md` got slug `foo` instead of `sub/foo`, making them unreachable via `memex read sub/foo`.

## Changes
1. **`src/lib/store.ts`**: Changed slug computation to `relative(cardsDir, fullPath).replace(/\.md$/, '')` — preserves subdirectory paths
2. **`src/lib/store.ts`**: Fixed `archiveCard()` to create parent directories for subdirectory cards
3. **`src/cli.ts`**: Added success message on write (`Wrote card: <slug>`)
4. **Tests updated**: Adjusted expected slugs and read commands for subdirectory cards

All 40 relevant tests pass.