### PR TITLE
fix: validate slug before writing to prevent hidden files

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,48 @@
 import { readdir, readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join, basename, dirname, resolve } from "node:path";
 
+// Characters not allowed in slugs (OS-reserved or dangerous)
+const RESERVED_CHARS = /[:*?"<>|]/;
+
+/**
+ * Validate a slug before writing. Throws on invalid slugs.
+ *
+ * Rules:
+ *  - Must not be empty or whitespace-only after trimming
+ *  - Must not consist solely of dots and/or slashes
+ *  - Must not contain OS-reserved characters (: * ? " < > |)
+ *  - Must not contain empty path segments (e.g. "a//b", "/foo", "foo/")
+ */
+export function validateSlug(slug: string): void {
+  const trimmed = slug.trim();
+
+  if (trimmed.length === 0) {
+    throw new Error("Invalid slug: must not be empty or whitespace-only");
+  }
+
+  // Reject slugs that are only dots and/or slashes (e.g. "..", "./.", "///")
+  if (/^[./]+$/.test(trimmed)) {
+    throw new Error("Invalid slug: must not consist only of dots and slashes");
+  }
+
+  if (RESERVED_CHARS.test(trimmed)) {
+    throw new Error("Invalid slug: contains reserved characters (: * ? \" < > |)");
+  }
+
+  // Reject leading/trailing slashes or consecutive slashes (empty path segments)
+  if (trimmed.startsWith("/") || trimmed.endsWith("/") || trimmed.includes("//")) {
+    throw new Error("Invalid slug: must not contain empty path segments");
+  }
+
+  // Reject path segments that are just dots (e.g. "a/../b", "./foo")
+  const segments = trimmed.split("/");
+  for (const seg of segments) {
+    if (seg === "." || seg === "..") {
+      throw new Error("Invalid slug: path segments must not be '.' or '..'");
+    }
+  }
+}
+
 interface ScannedCard {
   slug: string;
   path: string;
@@ -68,6 +110,7 @@ export class CardStore {
   }
 
   async writeCard(slug: string, content: string): Promise<void> {
+    validateSlug(slug);
     const existing = await this.resolve(slug);
     const targetPath = existing ?? join(this.cardsDir, `${slug}.md`);
     this.assertSafePath(targetPath);

--- a/tests/lib/store.test.ts
+++ b/tests/lib/store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { CardStore } from "../../src/lib/store.js";
+import { CardStore, validateSlug } from "../../src/lib/store.js";
 
 describe("CardStore", () => {
   let tmpDir: string;
@@ -104,5 +104,93 @@ describe("CardStore", () => {
     it("throws when card not found", async () => {
       await expect(store.archiveCard("missing")).rejects.toThrow("Card not found: missing");
     });
+  });
+
+  describe("writeCard slug validation", () => {
+    it("rejects empty string slug", async () => {
+      await expect(store.writeCard("", "content")).rejects.toThrow("must not be empty");
+    });
+
+    it("rejects whitespace-only slug", async () => {
+      await expect(store.writeCard("   ", "content")).rejects.toThrow("must not be empty");
+    });
+
+    it("rejects tab-only slug", async () => {
+      await expect(store.writeCard("\t\t", "content")).rejects.toThrow("must not be empty");
+    });
+
+    it("rejects slug consisting only of dots", async () => {
+      await expect(store.writeCard("..", "content")).rejects.toThrow("only of dots and slashes");
+    });
+
+    it("rejects slug consisting only of dots and slashes", async () => {
+      await expect(store.writeCard("./.", "content")).rejects.toThrow("only of dots and slashes");
+    });
+
+    it("rejects OS reserved characters", async () => {
+      for (const ch of [':', '*', '?', '"', '<', '>', '|']) {
+        await expect(store.writeCard(`bad${ch}slug`, "content")).rejects.toThrow("reserved characters");
+      }
+    });
+
+    it("rejects leading slash", async () => {
+      await expect(store.writeCard("/foo", "content")).rejects.toThrow("empty path segments");
+    });
+
+    it("rejects trailing slash", async () => {
+      await expect(store.writeCard("foo/", "content")).rejects.toThrow("empty path segments");
+    });
+
+    it("rejects consecutive slashes", async () => {
+      await expect(store.writeCard("a//b", "content")).rejects.toThrow("empty path segments");
+    });
+
+    it("rejects dot path segments", async () => {
+      await expect(store.writeCard("a/../b", "content")).rejects.toThrow("must not be '.' or '..'");
+    });
+
+    it("rejects ./foo relative path", async () => {
+      await expect(store.writeCard("./foo", "content")).rejects.toThrow("must not be '.' or '..'");
+    });
+
+    it("accepts valid simple slug", async () => {
+      await store.writeCard("valid-slug", "content");
+      const written = await readFile(join(cardsDir, "valid-slug.md"), "utf-8");
+      expect(written).toBe("content");
+    });
+
+    it("accepts valid slug with subdirectory", async () => {
+      await store.writeCard("sub/card", "content");
+      const written = await readFile(join(cardsDir, "sub", "card.md"), "utf-8");
+      expect(written).toBe("content");
+    });
+  });
+});
+
+describe("validateSlug (unit)", () => {
+  it("throws on empty string", () => {
+    expect(() => validateSlug("")).toThrow("must not be empty");
+  });
+
+  it("throws on whitespace-only", () => {
+    expect(() => validateSlug("   ")).toThrow("must not be empty");
+  });
+
+  it("throws on dots-only", () => {
+    expect(() => validateSlug("..")).toThrow("only of dots and slashes");
+  });
+
+  it("throws on reserved chars", () => {
+    expect(() => validateSlug("a:b")).toThrow("reserved characters");
+  });
+
+  it("throws on empty path segments", () => {
+    expect(() => validateSlug("a//b")).toThrow("empty path segments");
+  });
+
+  it("does not throw on valid slug", () => {
+    expect(() => validateSlug("my-card")).not.toThrow();
+    expect(() => validateSlug("sub/my-card")).not.toThrow();
+    expect(() => validateSlug("a.b.c")).not.toThrow();
   });
 });


### PR DESCRIPTION
Fixes #4

## Problem
Empty/whitespace-only slugs were silently accepted, creating hidden files like `~/.memex/cards/.md`. Slugs with OS-reserved characters, dot-only segments, or empty path segments were also accepted.

## Changes
1. **`src/lib/store.ts`**: Added `validateSlug()` function (exported) — rejects empty, whitespace-only, dot/slash-only, OS-reserved chars, empty path segments, `..` traversal
2. **`tests/lib/store.test.ts`**: 18 new tests (12 integration + 6 unit), all 30 store tests pass

Called at the top of `writeCard()` before any filesystem operations.