### PR TITLE
fix: search recursively across all directories, not just cards/ (fixes #10)

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,6 +1,8 @@
 import { CardStore } from "../lib/store.js";
 import { parseFrontmatter, extractLinks } from "../lib/parser.js";
 import { formatCardList, formatSearchResult } from "../lib/formatter.js";
+import { dirname } from "node:path";
+import { readFile } from "node:fs/promises";
 
 const DEFAULT_LIMIT = 10;
 
@@ -14,14 +16,19 @@ interface SearchResult {
 }
 
 export async function searchCommand(store: CardStore, query: string | undefined, options: SearchOptions = {}): Promise<SearchResult> {
-  const cards = await store.scanAll();
+  // When searching (query provided), scan all directories under MEMEX_HOME
+  // When listing (no query), only scan cards/ to avoid noise
+  const cards = query
+    ? await store.scanAllRecursive(dirname(store.cardsDir))
+    : await store.scanAll();
+
   if (cards.length === 0) return { output: "", exitCode: 0 };
 
   // No query: list all cards
   if (!query) {
     const items = await Promise.all(
       cards.map(async (c) => {
-        const raw = await store.readCard(c.slug);
+        const raw = await readFile(c.path, "utf-8");
         const { data } = parseFrontmatter(raw);
         return { slug: c.slug, title: String(data.title || c.slug) };
       })
@@ -36,7 +43,7 @@ export async function searchCommand(store: CardStore, query: string | undefined,
   const matchedCards: { slug: string; matchLine: string; matchCount: number }[] = [];
 
   for (const card of cards) {
-    const raw = await store.readCard(card.slug);
+    const raw = await readFile(card.path, "utf-8");
     const { data, content } = parseFrontmatter(raw);
     const title = String(data.title || card.slug);
     // Search title + body, case-insensitive
@@ -61,7 +68,7 @@ export async function searchCommand(store: CardStore, query: string | undefined,
 
   const results: string[] = [];
   for (const matched of topCards) {
-    const raw = await store.readCard(matched.slug);
+    const raw = await readFile(cards.find((c) => c.slug === matched.slug)!.path, "utf-8");
     const { data, content } = parseFrontmatter(raw);
     const links = extractLinks(content);
     const paragraphs = content.trim().split(/\n\n+/);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -69,6 +69,16 @@ export class CardStore {
     return results;
   }
 
+  /**
+   * Recursively scan all .md files under a given root directory.
+   * Unlike scanAll(), this is not cached and searches beyond cardsDir.
+   */
+  async scanAllRecursive(rootDir: string): Promise<ScannedCard[]> {
+    const results: ScannedCard[] = [];
+    await this.walkDir(rootDir, results);
+    return results;
+  }
+
   private async walkDir(dir: string, results: ScannedCard[]): Promise<void> {
     let entries;
     try {

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -106,4 +106,52 @@ When JWT revoke fails, use cache as fallback. See [[jwt-migration]].`
     const result = await searchCommand(store, "jwt");
     expect(result.output).toContain("## jwt-migration");
   });
+
+  it("searches recursively in directories beyond cards/", async () => {
+    // Create a projects/ directory alongside cards/
+    const projectsDir = join(tmpDir, "projects");
+    await mkdir(projectsDir, { recursive: true });
+    await writeFile(
+      join(projectsDir, "api-design.md"),
+      `---
+title: API Design
+created: 2026-03-23
+modified: 2026-03-23
+source: project
+---
+
+This project uses JWT authentication for API endpoints.`
+    );
+
+    // Search should find the JWT match in projects/ directory
+    const result = await searchCommand(store, "JWT");
+    expect(result.output).toContain("api-design");
+    expect(result.output).toContain("API Design");
+
+    // Should also still find cards/ directory results
+    expect(result.output).toContain("jwt-migration");
+  });
+
+  it("does not list files from other directories when no query", async () => {
+    // Create a projects/ directory alongside cards/
+    const projectsDir = join(tmpDir, "projects");
+    await mkdir(projectsDir, { recursive: true });
+    await writeFile(
+      join(projectsDir, "api-design.md"),
+      `---
+title: API Design
+created: 2026-03-23
+modified: 2026-03-23
+source: project
+---
+
+Some project content.`
+    );
+
+    // List (no query) should only show cards/ directory
+    const result = await searchCommand(store, undefined);
+    expect(result.output).toContain("jwt-migration");
+    expect(result.output).toContain("caching");
+    expect(result.output).not.toContain("api-design");
+  });
 });


### PR DESCRIPTION
## Problem

`memex search` only scans the `cards/` directory. Users who organize their knowledge base with additional directories (e.g. `projects/` alongside `cards/`) can't find matches in those files.

## Fix

- Added `scanAllRecursive(rootDir)` to CardStore that walks all `.md` files under any root directory
- `searchCommand()` now uses recursive scan (MEMEX_HOME root) when a query is provided
- Listing (no query) still only shows `cards/` to avoid noise
- Changed to read files directly by path instead of `store.readCard(slug)` (which only resolves cards/)
- Added 2 tests: recursive search finds matches in `projects/`, listing still only shows `cards/`

## Testing

- All 11 search tests pass (9 existing + 2 new)
- Build succeeds
- Backward compatible: `scanAll()` unchanged, `scanAllRecursive()` is additive

Fixes #10