### PR TITLE
feat: add --nested CLI flag for read and search commands (Phase 2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,11 @@ import { serveCommand } from "./commands/serve.js";
 import { syncCommand } from "./commands/sync.js";
 import { importCommand } from "./commands/import.js";
 
-async function getStore(): Promise<CardStore> {
+async function getStore(opts?: { nested?: boolean }): Promise<CardStore> {
   const home = process.env.MEMEX_HOME || join(homedir(), ".memex");
   const config = await readConfig(home);
-  return new CardStore(join(home, "cards"), join(home, "archive"), config.nestedSlugs);
+  const nestedSlugs = opts?.nested ?? config.nestedSlugs;
+  return new CardStore(join(home, "cards"), join(home, "archive"), nestedSlugs);
 }
 
 async function readStdin(): Promise<string> {
@@ -39,8 +40,9 @@ program
   .command("search [query]")
   .description("Full-text search cards (body only), or list all if no query")
   .option("-l, --limit <n>", "Max results to return", "10")
-  .action(async (query: string | undefined, opts: { limit: string }) => {
-    const store = await getStore();
+  .option("--nested", "Use nested (path-preserving) slugs for this command")
+  .action(async (query: string | undefined, opts: { limit: string; nested?: boolean }) => {
+    const store = await getStore({ nested: opts.nested });
     const result = await searchCommand(store, query, { limit: parseInt(opts.limit) });
     if (result.output) process.stdout.write(result.output + "\n");
     process.exit(result.exitCode);
@@ -49,8 +51,9 @@ program
 program
   .command("read <slug>")
   .description("Read a card's full content")
-  .action(async (slug: string) => {
-    const store = await getStore();
+  .option("--nested", "Use nested (path-preserving) slugs for this command")
+  .action(async (slug: string, opts: { nested?: boolean }) => {
+    const store = await getStore({ nested: opts.nested });
     const result = await readCommand(store, slug);
     if (result.success) {
       process.stdout.write(result.content! + "\n");

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -106,4 +106,43 @@ Nested content.`;
     const { stdout } = await run(`node ${CLI_PATH} search`, { env });
     expect(stdout).toContain("sub/nested");
   });
+
+  it("read --nested overrides config to use nested slugs", async () => {
+    // No .memexrc — nestedSlugs defaults to false
+    await mkdir(join(tmpDir, "cards", "deep"), { recursive: true });
+    await writeFile(
+      join(tmpDir, "cards", "deep", "card.md"),
+      "---\ntitle: Deep Card\ncreated: 2026-03-18\nsource: manual\n---\nDeep content."
+    );
+
+    // Without --nested, read "deep/card" fails (basename slug = "card")
+    try {
+      await run(`node ${CLI_PATH} read deep/card`, { env });
+      expect.fail("should have thrown");
+    } catch (e: any) {
+      expect(e.stderr).toContain("Card not found");
+    }
+
+    // With --nested, read "deep/card" succeeds
+    const { stdout } = await run(`node ${CLI_PATH} read --nested deep/card`, { env });
+    expect(stdout).toContain("Deep Card");
+    expect(stdout).toContain("Deep content.");
+  });
+
+  it("search --nested shows full paths without config", async () => {
+    // No .memexrc — nestedSlugs defaults to false
+    await mkdir(join(tmpDir, "cards", "sub"), { recursive: true });
+    await writeFile(
+      join(tmpDir, "cards", "sub", "item.md"),
+      "---\ntitle: Sub Item\ncreated: 2026-03-18\nmodified: 2026-03-18\nsource: manual\n---\nSub content."
+    );
+
+    // Without --nested, search shows basename only
+    const { stdout: flat } = await run(`node ${CLI_PATH} search`, { env });
+    expect(flat).not.toContain("sub/item");
+
+    // With --nested, search shows full path slug
+    const { stdout: nested } = await run(`node ${CLI_PATH} search --nested`, { env });
+    expect(nested).toContain("sub/item");
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2 of issue #2 — adds `--nested` CLI flag to `read` and `search` commands.

This allows one-off hierarchical slug access without needing to set `nestedSlugs: true` in `.memexrc`.

## Changes

- **`getStore()`**: Refactored to accept optional `{ nested?: boolean }` override parameter
- **`memex read --nested <slug>`**: Resolves nested (path-preserving) slugs even when config is off
- **`memex search --nested`**: Displays full path slugs in search results

## Examples

```bash
# Read a nested card without config change
memex read --nested sub/my-card

# List all cards with full paths
memex search --nested

# Search with full paths
memex search --nested "query"
```

## Tests

- 2 new integration tests verifying --nested override behavior
- All 265 tests pass

## Context

- Phase 1 (config option): PR #19 ✅ merged
- **Phase 2 (CLI flags): this PR**
- Phase 3 (migration helper): planned next

Closes phase 2 of #2.