### PR TITLE
feat: add doctor and migrate commands for nestedSlugs (Phase 3)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,8 @@ import { archiveCommand } from "./commands/archive.js";
 import { serveCommand } from "./commands/serve.js";
 import { syncCommand } from "./commands/sync.js";
 import { importCommand } from "./commands/import.js";
+import { doctorCommand } from "./commands/doctor.js";
+import { migrateCommand } from "./commands/migrate.js";
 
 async function getStore(): Promise<CardStore> {
   const home = process.env.MEMEX_HOME || join(homedir(), ".memex");
@@ -165,6 +167,47 @@ program
     if (result.output) process.stdout.write(result.output + "\n");
     if (!result.success) {
       if (result.error) process.stderr.write(result.error + "\n");
+      process.exit(1);
+    }
+  });
+
+program
+  .command("doctor")
+  .description("Check memex health and configuration")
+  .option("--check-collisions", "Check for slug collisions in basename mode")
+  .action(async (opts: { checkCollisions?: boolean }) => {
+    const home = process.env.MEMEX_HOME || join(homedir(), ".memex");
+    const cardsDir = join(home, "cards");
+    const archiveDir = join(home, "archive");
+
+    if (opts.checkCollisions) {
+      const result = await doctorCommand(cardsDir, archiveDir);
+      if (result.output) process.stdout.write(result.output + "\n");
+      process.exit(result.exitCode);
+    } else {
+      process.stderr.write("No check specified. Use --check-collisions to check for slug collisions.\n");
+      process.exit(1);
+    }
+  });
+
+program
+  .command("migrate")
+  .description("Migrate memex configuration")
+  .option("--enable-nested", "Enable nestedSlugs in config")
+  .action(async (opts: { enableNested?: boolean }) => {
+    const home = process.env.MEMEX_HOME || join(homedir(), ".memex");
+    const cardsDir = join(home, "cards");
+    const archiveDir = join(home, "archive");
+
+    if (opts.enableNested) {
+      const result = await migrateCommand(home, cardsDir, archiveDir);
+      if (result.output) process.stdout.write(result.output + "\n");
+      if (!result.success) {
+        if (result.error) process.stderr.write(result.error + "\n");
+        process.exit(1);
+      }
+    } else {
+      process.stderr.write("No migration specified. Use --enable-nested to enable nestedSlugs.\n");
       process.exit(1);
     }
   });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,77 @@
+import { CardStore } from "../lib/store.js";
+
+interface DoctorResult {
+  exitCode: number;
+  output?: string;
+}
+
+interface CollisionGroup {
+  slug: string;
+  paths: string[];
+  fullPaths: string[];
+}
+
+export async function doctorCommand(
+  cardsDir: string,
+  archiveDir: string
+): Promise<DoctorResult> {
+  try {
+    // Scan with basename mode (nestedSlugs=false) to find collisions
+    const basenameStore = new CardStore(cardsDir, archiveDir, false);
+    const cards = await basenameStore.scanAll();
+
+    // Group by slug to find collisions
+    const slugMap = new Map<string, string[]>();
+    for (const card of cards) {
+      if (!slugMap.has(card.slug)) {
+        slugMap.set(card.slug, []);
+      }
+      slugMap.get(card.slug)!.push(card.path);
+    }
+
+    // Find collision groups (slugs with multiple paths)
+    const collisions: CollisionGroup[] = [];
+    for (const [slug, paths] of slugMap.entries()) {
+      if (paths.length > 1) {
+        // Get full paths using nested mode
+        const nestedStore = new CardStore(cardsDir, archiveDir, true);
+        const nestedCards = await nestedStore.scanAll();
+        const fullPaths = paths.map((path) => {
+          const found = nestedCards.find((c) => c.path === path);
+          return found?.slug ?? path;
+        });
+
+        collisions.push({ slug, paths, fullPaths });
+      }
+    }
+
+    if (collisions.length === 0) {
+      return {
+        exitCode: 0,
+        output: "No slug collisions found. Safe to enable nestedSlugs.",
+      };
+    }
+
+    // Build collision report
+    const lines: string[] = [`Found ${collisions.length} slug collision(s):\n`];
+    for (const collision of collisions) {
+      lines.push(`Slug "${collision.slug}" collides:`);
+      for (let i = 0; i < collision.paths.length; i++) {
+        lines.push(`  - ${collision.paths[i]}`);
+        lines.push(`    (would become: ${collision.fullPaths[i]})`);
+      }
+      lines.push("");
+    }
+    lines.push("Resolve these collisions before enabling nestedSlugs.");
+
+    return {
+      exitCode: 1,
+      output: lines.join("\n"),
+    };
+  } catch (e) {
+    return {
+      exitCode: 1,
+      output: `Error checking collisions: ${(e as Error).message}`,
+    };
+  }
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,54 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { doctorCommand } from "./doctor.js";
+
+interface MigrateResult {
+  success: boolean;
+  output?: string;
+  error?: string;
+}
+
+export async function migrateCommand(
+  memexHome: string,
+  cardsDir: string,
+  archiveDir: string
+): Promise<MigrateResult> {
+  try {
+    // First check for collisions
+    const doctorResult = await doctorCommand(cardsDir, archiveDir);
+    if (doctorResult.exitCode !== 0) {
+      return {
+        success: false,
+        error: `${doctorResult.output}\n\nResolve collisions before enabling nestedSlugs.`,
+      };
+    }
+
+    // No collisions, safe to enable nestedSlugs
+    const configPath = join(memexHome, ".memexrc");
+    let config: Record<string, unknown> = {};
+
+    // Read existing config if it exists
+    try {
+      const content = await readFile(configPath, "utf-8");
+      config = JSON.parse(content);
+    } catch {
+      // File doesn't exist or invalid JSON - start with empty config
+    }
+
+    // Set nestedSlugs to true
+    config.nestedSlugs = true;
+
+    // Write config back
+    await writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+
+    return {
+      success: true,
+      output: `✓ Enabled nestedSlugs in ${configPath}\n${doctorResult.output}`,
+    };
+  } catch (e) {
+    return {
+      success: false,
+      error: `Failed to enable nestedSlugs: ${(e as Error).message}`,
+    };
+  }
+}

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { doctorCommand } from "../../src/commands/doctor.js";
+
+describe("doctorCommand", () => {
+  let tmpDir: string;
+  let cardsDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-"));
+    cardsDir = join(tmpDir, "cards");
+    archiveDir = join(tmpDir, "archive");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports no collisions when all slugs are unique", async () => {
+    await writeFile(join(cardsDir, "foo.md"), "foo content");
+    await writeFile(join(cardsDir, "bar.md"), "bar content");
+
+    const result = await doctorCommand(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("No slug collisions found");
+    expect(result.output).toContain("Safe to enable nestedSlugs");
+  });
+
+  it("detects collision when basename slugs match", async () => {
+    await mkdir(join(cardsDir, "sub"), { recursive: true });
+    await writeFile(join(cardsDir, "foo.md"), "foo root");
+    await writeFile(join(cardsDir, "sub", "foo.md"), "foo sub");
+
+    const result = await doctorCommand(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('Found 1 slug collision');
+    expect(result.output).toContain('Slug "foo" collides');
+    expect(result.output).toContain("Resolve these collisions");
+  });
+
+  it("detects multiple collision groups", async () => {
+    await mkdir(join(cardsDir, "a"), { recursive: true });
+    await mkdir(join(cardsDir, "b"), { recursive: true });
+    await writeFile(join(cardsDir, "test.md"), "test root");
+    await writeFile(join(cardsDir, "a", "test.md"), "test a");
+    await writeFile(join(cardsDir, "demo.md"), "demo root");
+    await writeFile(join(cardsDir, "b", "demo.md"), "demo b");
+
+    const result = await doctorCommand(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Found 2 slug collision");
+    expect(result.output).toContain('Slug "test" collides');
+    expect(result.output).toContain('Slug "demo" collides');
+  });
+
+  it("shows full paths in collision report", async () => {
+    await mkdir(join(cardsDir, "nested", "deep"), { recursive: true });
+    await writeFile(join(cardsDir, "card.md"), "card root");
+    await writeFile(join(cardsDir, "nested", "deep", "card.md"), "card nested");
+
+    const result = await doctorCommand(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("would become: card");
+    expect(result.output).toContain("would become: nested/deep/card");
+  });
+});

--- a/tests/commands/migrate.test.ts
+++ b/tests/commands/migrate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateCommand } from "../../src/commands/migrate.js";
+
+describe("migrateCommand", () => {
+  let tmpDir: string;
+  let cardsDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-"));
+    cardsDir = join(tmpDir, "cards");
+    archiveDir = join(tmpDir, "archive");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("enables nestedSlugs when no collisions exist", async () => {
+    await writeFile(join(cardsDir, "foo.md"), "foo");
+    await writeFile(join(cardsDir, "bar.md"), "bar");
+
+    const result = await migrateCommand(tmpDir, cardsDir, archiveDir);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Enabled nestedSlugs");
+    expect(result.output).toContain("No slug collisions found");
+
+    const configPath = join(tmpDir, ".memexrc");
+    const config = JSON.parse(await readFile(configPath, "utf-8"));
+    expect(config.nestedSlugs).toBe(true);
+  });
+
+  it("creates .memexrc if it doesn't exist", async () => {
+    await writeFile(join(cardsDir, "test.md"), "test");
+
+    const result = await migrateCommand(tmpDir, cardsDir, archiveDir);
+    expect(result.success).toBe(true);
+
+    const configPath = join(tmpDir, ".memexrc");
+    const config = JSON.parse(await readFile(configPath, "utf-8"));
+    expect(config).toEqual({ nestedSlugs: true });
+  });
+
+  it("preserves existing config settings", async () => {
+    await writeFile(join(cardsDir, "test.md"), "test");
+    const configPath = join(tmpDir, ".memexrc");
+    await writeFile(configPath, JSON.stringify({ customSetting: "value" }));
+
+    const result = await migrateCommand(tmpDir, cardsDir, archiveDir);
+    expect(result.success).toBe(true);
+
+    const config = JSON.parse(await readFile(configPath, "utf-8"));
+    expect(config.nestedSlugs).toBe(true);
+    expect(config.customSetting).toBe("value");
+  });
+
+  it("aborts when collisions exist", async () => {
+    await mkdir(join(cardsDir, "sub"), { recursive: true });
+    await writeFile(join(cardsDir, "collision.md"), "root");
+    await writeFile(join(cardsDir, "sub", "collision.md"), "sub");
+
+    const result = await migrateCommand(tmpDir, cardsDir, archiveDir);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Slug "collision" collides');
+    expect(result.error).toContain("Resolve collisions before enabling nestedSlugs");
+  });
+
+  it("does not create .memexrc when collisions exist", async () => {
+    await mkdir(join(cardsDir, "sub"), { recursive: true });
+    await writeFile(join(cardsDir, "collision.md"), "root");
+    await writeFile(join(cardsDir, "sub", "collision.md"), "sub");
+
+    await migrateCommand(tmpDir, cardsDir, archiveDir);
+
+    try {
+      await readFile(join(tmpDir, ".memexrc"), "utf-8");
+      expect.fail("Should not create .memexrc when collisions exist");
+    } catch (e) {
+      expect((e as NodeJS.ErrnoException).code).toBe("ENOENT");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of issue #2 — migration helper for safe nestedSlugs adoption.

## New Commands

### `memex doctor --check-collisions`
Detects basename slug collisions — cases where enabling nestedSlugs would change slug resolution.

```bash
$ memex doctor --check-collisions
Found 1 slug collision(s):

Slug "foo" collides:
  - /path/to/cards/foo.md
    (would become: foo)
  - /path/to/cards/sub/foo.md
    (would become: sub/foo)

Resolve these collisions before enabling nestedSlugs.
```

Exit code 0 if clean, 1 if collisions found.

### `memex migrate --enable-nested`
Safely enables nestedSlugs in `.memexrc` after verifying no collisions.

```bash
$ memex migrate --enable-nested
✓ Enabled nestedSlugs in /home/user/.memex/.memexrc
No slug collisions found. Safe to enable nestedSlugs.
```

Key behaviors:
- Runs collision check internally before enabling
- Aborts with collision report if conflicts found
- Preserves existing `.memexrc` settings (merge, not overwrite)
- Creates `.memexrc` if it doesn't exist

## Tests

- 4 doctor tests (no collisions, single collision, multiple collisions, full path display)
- 5 migrate tests (enable, create config, preserve settings, abort on collision, no write on collision)
- All 272 tests pass

## Context

- Phase 1 (config option): PR #19 ✅ merged
- Phase 2 (CLI flags): PR #20
- **Phase 3 (migration helper): this PR**

Completes the full implementation plan from #2.