### PR TITLE
feat: add multi-directory search with --all flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,9 +43,12 @@ program
   .description("Full-text search cards (body only), or list all if no query")
   .option("-l, --limit <n>", "Max results to return", "10")
   .option("--nested", "Use nested (path-preserving) slugs for this command")
-  .action(async (query: string | undefined, opts: { limit: string; nested?: boolean }) => {
+  .option("--all", "Search across all configured searchDirs in addition to cards/")
+  .action(async (query: string | undefined, opts: { limit: string; nested?: boolean; all?: boolean }) => {
+    const home = process.env.MEMEX_HOME || join(homedir(), ".memex");
+    const config = await readConfig(home);
     const store = await getStore({ nested: opts.nested });
-    const result = await searchCommand(store, query, { limit: parseInt(opts.limit) });
+    const result = await searchCommand(store, query, { limit: parseInt(opts.limit), all: opts.all, config, memexHome: home });
     if (result.output) process.stdout.write(result.output + "\n");
     process.exit(result.exitCode);
   });

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,11 +1,16 @@
 import { CardStore } from "../lib/store.js";
 import { parseFrontmatter, extractLinks } from "../lib/parser.js";
 import { formatCardList, formatSearchResult } from "../lib/formatter.js";
+import { MemexConfig } from "../lib/config.js";
+import { join } from "node:path";
 
 const DEFAULT_LIMIT = 10;
 
 interface SearchOptions {
   limit?: number;
+  all?: boolean;
+  config?: MemexConfig;
+  memexHome?: string;
 }
 
 interface SearchResult {
@@ -14,16 +19,44 @@ interface SearchResult {
 }
 
 export async function searchCommand(store: CardStore, query: string | undefined, options: SearchOptions = {}): Promise<SearchResult> {
-  const cards = await store.scanAll();
-  if (cards.length === 0) return { output: "", exitCode: 0 };
+  // Gather all stores to search
+  const storesToSearch: Array<{ store: CardStore; dirPrefix: string }> = [
+    { store, dirPrefix: "cards" }
+  ];
+
+  // Add additional search directories if --all is set
+  if (options.all && options.config?.searchDirs && options.config.searchDirs.length > 0 && options.memexHome) {
+    const archiveDir = join(options.memexHome, "archive");
+    for (const searchDir of options.config.searchDirs) {
+      const fullPath = join(options.memexHome, searchDir);
+      const additionalStore = new CardStore(fullPath, archiveDir, store["nestedSlugs"]);
+      const dirName = searchDir.split("/").pop() || searchDir;
+      storesToSearch.push({ store: additionalStore, dirPrefix: dirName });
+    }
+  }
+
+  // Only prefix slugs if we're actually searching multiple directories
+  const shouldPrefix = storesToSearch.length > 1;
+
+  // Collect all cards from all stores
+  const allCards: Array<{ slug: string; store: CardStore; dirPrefix: string }> = [];
+  for (const { store: s, dirPrefix } of storesToSearch) {
+    const cards = await s.scanAll();
+    for (const card of cards) {
+      allCards.push({ slug: card.slug, store: s, dirPrefix });
+    }
+  }
+
+  if (allCards.length === 0) return { output: "", exitCode: 0 };
 
   // No query: list all cards
   if (!query) {
     const items = await Promise.all(
-      cards.map(async (c) => {
-        const raw = await store.readCard(c.slug);
+      allCards.map(async (c) => {
+        const raw = await c.store.readCard(c.slug);
         const { data } = parseFrontmatter(raw);
-        return { slug: c.slug, title: String(data.title || c.slug) };
+        const prefixedSlug = shouldPrefix ? `${c.dirPrefix}/${c.slug}` : c.slug;
+        return { slug: prefixedSlug, title: String(data.title || c.slug) };
       })
     );
     return { output: formatCardList(items), exitCode: 0 };
@@ -33,14 +66,14 @@ export async function searchCommand(store: CardStore, query: string | undefined,
   const rawLimit = options.limit ?? DEFAULT_LIMIT;
   // Clamp limit to a safe positive range; 0 returns no results (intentional)
   const limit = rawLimit < 0 ? DEFAULT_LIMIT : rawLimit;
-  const matchedCards: { slug: string; matchLine: string; matchCount: number }[] = [];
+  const matchedCards: { slug: string; matchLine: string; matchCount: number; store: CardStore; dirPrefix: string }[] = [];
 
   // Split query into tokens — ALL tokens must appear (AND logic)
   const tokens = query.split(/\s+/).filter(Boolean);
   const escapedTokens = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
 
-  for (const card of cards) {
-    const raw = await store.readCard(card.slug);
+  for (const card of allCards) {
+    const raw = await card.store.readCard(card.slug);
     const { data, content } = parseFrontmatter(raw);
     const title = String(data.title || card.slug);
     const searchText = title + "\n" + content;
@@ -60,7 +93,7 @@ export async function searchCommand(store: CardStore, query: string | undefined,
     const lineRegex = new RegExp(escapedTokens[0], "i");
     const bodyLines = content.split("\n");
     const matchLine = bodyLines.find((l) => lineRegex.test(l))?.trim() || "";
-    matchedCards.push({ slug: card.slug, matchLine, matchCount });
+    matchedCards.push({ slug: card.slug, matchLine, matchCount, store: card.store, dirPrefix: card.dirPrefix });
   }
 
   if (matchedCards.length === 0) return { output: "", exitCode: 0 };
@@ -71,7 +104,7 @@ export async function searchCommand(store: CardStore, query: string | undefined,
 
   const results: string[] = [];
   for (const matched of topCards) {
-    const raw = await store.readCard(matched.slug);
+    const raw = await matched.store.readCard(matched.slug);
     const { data, content } = parseFrontmatter(raw);
     const links = extractLinks(content);
     const paragraphs = content.trim().split(/\n\n+/);
@@ -79,9 +112,11 @@ export async function searchCommand(store: CardStore, query: string | undefined,
 
     const showMatchLine = matched.matchLine && !firstParagraph.includes(matched.matchLine) ? matched.matchLine : null;
 
+    const prefixedSlug = shouldPrefix ? `${matched.dirPrefix}/${matched.slug}` : matched.slug;
+
     results.push(
       formatSearchResult({
-        slug: matched.slug,
+        slug: prefixedSlug,
         title: String(data.title || matched.slug),
         firstParagraph,
         matchLine: showMatchLine,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 export interface MemexConfig {
   nestedSlugs: boolean;
+  searchDirs?: string[];
 }
 
 /**
@@ -18,6 +19,7 @@ export async function readConfig(memexHome: string): Promise<MemexConfig> {
 
     return {
       nestedSlugs: parsed.nestedSlugs === true,
+      searchDirs: Array.isArray(parsed.searchDirs) ? parsed.searchDirs : undefined,
     };
   } catch {
     // File doesn't exist or invalid JSON - return defaults

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { searchCommand } from "../../src/commands/search.js";
 import { CardStore } from "../../src/lib/store.js";
+import { MemexConfig } from "../../src/lib/config.js";
 
 describe("searchCommand", () => {
   let tmpDir: string;
@@ -105,5 +106,112 @@ When JWT revoke fails, use cache as fallback. See [[jwt-migration]].`
   it("is case-insensitive", async () => {
     const result = await searchCommand(store, "jwt");
     expect(result.output).toContain("## jwt-migration");
+  });
+});
+
+describe("searchCommand with --all flag (multi-directory)", () => {
+  let tmpDir: string;
+  let memexHome: string;
+  let store: CardStore;
+  let config: MemexConfig;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-multi-"));
+    memexHome = tmpDir;
+    const cardsDir = join(tmpDir, "cards");
+    const projectsDir = join(tmpDir, "projects");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(projectsDir, { recursive: true });
+    store = new CardStore(cardsDir, join(tmpDir, "archive"));
+
+    // Card in cards/
+    await writeFile(
+      join(cardsDir, "auth.md"),
+      `---
+title: Authentication
+created: 2026-03-18
+---
+
+Basic authentication concepts.`
+    );
+
+    // Card in projects/
+    await writeFile(
+      join(projectsDir, "api-design.md"),
+      `---
+title: API Design
+created: 2026-03-18
+---
+
+REST API design patterns.`
+    );
+
+    // Another card in projects/
+    await writeFile(
+      join(projectsDir, "deployment.md"),
+      `---
+title: Deployment Guide
+created: 2026-03-18
+---
+
+How to deploy the authentication service.`
+    );
+
+    config = {
+      nestedSlugs: false,
+      searchDirs: ["projects"],
+    };
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("searches only cards/ when --all is not set", async () => {
+    const result = await searchCommand(store, "API");
+    expect(result.output).not.toContain("api-design");
+    expect(result.output).toBe("");
+  });
+
+  it("searches cards/ and projects/ when --all is set", async () => {
+    const result = await searchCommand(store, "API", { all: true, config, memexHome });
+    expect(result.output).toContain("projects/api-design");
+    expect(result.output).toContain("API Design");
+  });
+
+  it("prefixes slugs with directory name when using --all", async () => {
+    const result = await searchCommand(store, "authentication", { all: true, config, memexHome });
+    expect(result.output).toContain("cards/auth");
+    expect(result.output).toContain("projects/deployment");
+  });
+
+  it("lists all cards from all directories when --all is set without query", async () => {
+    const result = await searchCommand(store, undefined, { all: true, config, memexHome });
+    expect(result.output).toContain("cards/auth");
+    expect(result.output).toContain("projects/api-design");
+    expect(result.output).toContain("projects/deployment");
+  });
+
+  it("works with empty searchDirs config", async () => {
+    const emptyConfig: MemexConfig = {
+      nestedSlugs: false,
+      searchDirs: [],
+    };
+    const result = await searchCommand(store, "authentication", { all: true, config: emptyConfig, memexHome });
+    // Empty searchDirs means only cards/ is searched, no prefix
+    expect(result.output).toContain("## auth");
+    expect(result.output).not.toContain("projects/");
+    expect(result.output).not.toContain("cards/");
+  });
+
+  it("works with undefined searchDirs", async () => {
+    const noSearchDirsConfig: MemexConfig = {
+      nestedSlugs: false,
+    };
+    const result = await searchCommand(store, "authentication", { all: true, config: noSearchDirsConfig, memexHome });
+    // Undefined searchDirs means only cards/ is searched, no prefix
+    expect(result.output).toContain("## auth");
+    expect(result.output).not.toContain("projects/");
+    expect(result.output).not.toContain("cards/");
   });
 });

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -49,4 +49,22 @@ describe("readConfig", () => {
     const config = await readConfig(tmpDir);
     expect(config).toEqual({ nestedSlugs: false });
   });
+
+  it("reads searchDirs from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: true, searchDirs: ["projects", "notes"] }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: true, searchDirs: ["projects", "notes"] });
+  });
+
+  it("treats non-array searchDirs as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false, searchDirs: "projects" }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false, searchDirs: undefined });
+  });
+
+  it("treats missing searchDirs field as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1 of multi-directory search as discussed in #22.

Adds `searchDirs` config option and `--all` flag to search across multiple directories beyond just `cards/`.

## Changes

### Config (`src/lib/config.ts`)
- Added optional `searchDirs?: string[]` field to `MemexConfig`
- Parsed from `.memexrc` (defaults to empty if missing or not an array)

### CLI (`src/cli.ts`)
- Added `--all` flag to `search` command
- Passes config and memexHome to searchCommand when `--all` is set

### Search (`src/commands/search.ts`)
- When `--all` + `searchDirs` configured: creates CardStore per additional dir, merges results
- **Slug disambiguation**: prefixes slugs with dir name (`cards/auth`, `projects/auth`) only when multiple dirs are searched
- Without `--all` or with empty searchDirs: behavior is 100% unchanged

### Tests
- 6 new tests for multi-dir search scenarios
- 3 new tests for searchDirs config parsing
- All 283 tests passing ✅

## Usage

```json
// .memexrc
{
  "searchDirs": ["projects", "notes"]
}
```

```bash
# Default (only cards/)
memex search "authentication"

# Search cards/ + projects/ + notes/
memex search --all "authentication"
```

## Next phases (from #22 discussion)
- Phase 2: `context` command (combines search + backlinks)
- Phase 3: Context-aware retrieval workflows

Closes #22 (Phase 1)