### PR TITLE
fix: graceful fallback on frontmatter parse errors (fixes #27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@touchskyer/memex",
-  "version": "0.1.22",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@touchskyer/memex",
-      "version": "0.1.22",
+      "version": "0.1.25",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -6,8 +6,15 @@ export interface ParsedCard {
 }
 
 export function parseFrontmatter(raw: string): ParsedCard {
-  const { data, content } = matter(raw);
-  return { data, content };
+  try {
+    const { data, content } = matter(raw);
+    return { data, content };
+  } catch {
+    // Frontmatter parse failed (e.g. YAML special chars like # in values).
+    // Fall back: treat entire file as content with empty metadata.
+    const stripped = raw.replace(/^---[\s\S]*?---\n?/, "");
+    return { data: {}, content: stripped || raw };
+  }
 }
 
 export function stringifyFrontmatter(

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -23,6 +23,21 @@ Body content here.`;
     expect(result.data).toEqual({});
     expect(result.content).toBe("Just plain text.");
   });
+
+  it("gracefully handles unparseable YAML frontmatter (fixes #27)", () => {
+    // The `#1)` triggers a YAML parse error: js-yaml treats # as comment start
+    const content = `---
+title: Agent Memory Taxonomy
+source: "Memory in the Age of AI Agents" (arxiv 2512.13564, HF Daily Paper #1)
+---
+
+Body content here.`;
+
+    const result = parseFrontmatter(content);
+    // Should not throw — returns fallback with empty data
+    expect(result.data).toEqual({});
+    expect(result.content).toContain("Body content here.");
+  });
 });
 
 describe("extractLinks", () => {


### PR DESCRIPTION
## Problem

A single card with YAML-unfriendly frontmatter (e.g. `#` inside parentheses being parsed as a comment) crashes the entire `memex search` / `memex links` / `memex organize` command with an unhandled `YAMLException`.

**Real-world example** — this frontmatter crashes all commands:
```yaml
source: "Memory in the Age of AI Agents" (arxiv 2512.13564, HF Daily Paper #1)
```

js-yaml interprets `#1)` as the start of a YAML comment, causing a parse error.

## Fix

`parseFrontmatter()` now catches the error and falls back gracefully:
- Returns **empty metadata** (`data: {}`)
- Strips the frontmatter block and returns **body content** as-is
- The card is still searchable by body text; title falls back to slug

This is a 3-line change in `src/lib/parser.ts`.

## Test

Added a regression test in `tests/lib/parser.test.ts` that reproduces the exact pattern that triggered the crash.

All 24 parser tests pass.

Closes #27