### PR TITLE
feat: support custom OpenAI base URL for embeddings

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -269,6 +269,7 @@ async function semanticSearch(
       provider = await createEmbeddingProvider({
         type: options.config?.embeddingProvider,
         openaiApiKey: options.config?.openaiApiKey,
+        openaiBaseUrl: options.config?.openaiBaseUrl,
         localModelPath: options.config?.localModelPath,
         ollamaModel: options.config?.ollamaModel,
         ollamaBaseUrl: options.config?.ollamaBaseUrl,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,7 @@ export interface MemexConfig {
   nestedSlugs: boolean;
   searchDirs?: string[];
   openaiApiKey?: string;
+  openaiBaseUrl?: string;
   embeddingModel?: string;
   /** Embedding provider: "openai" | "local" | "ollama". Auto-detected if omitted. */
   embeddingProvider?: EmbeddingProviderType;
@@ -32,6 +33,7 @@ export async function readConfig(memexHome: string): Promise<MemexConfig> {
       nestedSlugs: parsed.nestedSlugs === true,
       searchDirs: Array.isArray(parsed.searchDirs) ? parsed.searchDirs : undefined,
       openaiApiKey: typeof parsed.openaiApiKey === "string" ? parsed.openaiApiKey : undefined,
+      openaiBaseUrl: typeof parsed.openaiBaseUrl === "string" ? parsed.openaiBaseUrl : undefined,
       embeddingModel: typeof parsed.embeddingModel === "string" ? parsed.embeddingModel : undefined,
       embeddingProvider: isValidProvider(parsed.embeddingProvider) ? parsed.embeddingProvider : undefined,
       ollamaModel: typeof parsed.ollamaModel === "string" ? parsed.ollamaModel : undefined,

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -22,11 +22,17 @@ export type EmbeddingProviderType = "openai" | "local" | "ollama";
  * OpenAI embedding provider using text-embedding-3-small (1536 dims).
  * Uses native Node `https` module — no external dependencies.
  */
-export class OpenAIEmbeddingProvider implements EmbeddingProvider {
-  readonly model = "text-embedding-3-small";
-  private apiKey: string;
+const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
 
-  constructor(apiKey?: string) {
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string;
+  private apiKey: string;
+  private baseHostname: string;
+  private basePath: string;
+  private basePort: number | undefined;
+  private useHttp: boolean;
+
+  constructor(apiKey?: string, model?: string, baseUrl?: string) {
     const key = apiKey ?? process.env.OPENAI_API_KEY;
     if (!key) {
       throw new Error(
@@ -34,6 +40,14 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       );
     }
     this.apiKey = key;
+    this.model = model ?? DEFAULT_EMBEDDING_MODEL;
+
+    const url = baseUrl ?? process.env.OPENAI_BASE_URL ?? "https://api.openai.com";
+    const parsed = new URL(url);
+    this.baseHostname = parsed.hostname;
+    this.basePath = parsed.pathname.replace(/\/$/, "");
+    this.basePort = parsed.port ? Number(parsed.port) : undefined;
+    this.useHttp = parsed.protocol === "http:";
   }
 
   async embed(texts: string[]): Promise<number[][]> {
@@ -59,18 +73,22 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
         input: texts,
       });
 
-      const req = httpsRequest(
-        {
-          hostname: "api.openai.com",
-          path: "/v1/embeddings",
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.apiKey}`,
-            "Content-Length": Buffer.byteLength(body),
-          },
+      const reqFn = this.useHttp ? httpRequest : httpsRequest;
+      const reqOptions: Record<string, unknown> = {
+        hostname: this.baseHostname,
+        path: `${this.basePath}/v1/embeddings`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Length": Buffer.byteLength(body),
         },
-        (res) => {
+      };
+      if (this.basePort) reqOptions.port = this.basePort;
+
+      const req = reqFn(
+        reqOptions as any,
+        (res: any) => {
           let data = "";
           res.on("data", (chunk: Buffer) => {
             data += chunk.toString();
@@ -404,6 +422,8 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
 export interface CreateProviderOptions {
   type?: EmbeddingProviderType;
   openaiApiKey?: string;
+  openaiBaseUrl?: string;
+  openaiModel?: string;
   localModelPath?: string;
   ollamaModel?: string;
   ollamaBaseUrl?: string;
@@ -426,7 +446,7 @@ export async function createEmbeddingProvider(
 
   // Explicit provider requested
   if (requestedType === "openai") {
-    return new OpenAIEmbeddingProvider(options.openaiApiKey);
+    return new OpenAIEmbeddingProvider(options.openaiApiKey, options.openaiModel, options.openaiBaseUrl);
   }
   if (requestedType === "local") {
     return new LocalEmbeddingProvider(options.localModelPath);
@@ -441,7 +461,7 @@ export async function createEmbeddingProvider(
   // Auto-detect: try OpenAI first, then local, then ollama
   const apiKey = options.openaiApiKey ?? process.env.OPENAI_API_KEY;
   if (apiKey) {
-    return new OpenAIEmbeddingProvider(apiKey);
+    return new OpenAIEmbeddingProvider(apiKey, options.openaiModel, options.openaiBaseUrl);
   }
 
   // Try local (node-llama-cpp)


### PR DESCRIPTION
## Summary

Adds support for custom OpenAI-compatible API endpoints in the embedding provider, enabling semantic search with services like vLLM, Ollama, LiteLLM, and other OpenAI-compatible APIs.

## Changes

- `OpenAIEmbeddingProvider` now accepts an optional `baseUrl` parameter
- Supports `OPENAI_BASE_URL` environment variable (standard OpenAI SDK convention)
- Supports `openaiBaseUrl` in `.memexrc` configuration
- Adds HTTP support for local endpoints (not just HTTPS)

## Motivation

The current implementation hardcodes `api.openai.com`, making it impossible to use semantic search with self-hosted or alternative embedding providers. Many users run local inference servers (vLLM, Ollama) or use proxy services that expose OpenAI-compatible `/v1/embeddings` endpoints.

This follows the same pattern as the official OpenAI SDK (`OPENAI_BASE_URL` env var).

## Configuration

```json
// .memexrc
{
  "openaiBaseUrl": "http://localhost:8000",
  "openaiApiKey": "your-key",
  "embeddingModel": "text-embedding-3-small"
}
```

Or via environment:
```bash
export OPENAI_BASE_URL=http://localhost:8000
export OPENAI_API_KEY=your-key
memex search 'query' -s
```

## Testing

Tested with a vLLM server running `text-embedding-3-small`, successfully indexed and searched 87 cards.