### PR TITLE
fix: register organize command in CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { importCommand } from "./commands/import.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { migrateCommand } from "./commands/migrate.js";
 import { backlinksCommand } from "./commands/backlinks.js";
+import { organizeCommand } from "./commands/organize.js";
 import { flomoConfigCommand, flomoPushCommand, flomoImportCommand } from "./commands/flomo.js";
 
 async function getStore(opts?: { nested?: boolean }): Promise<CardStore> {
@@ -194,6 +195,18 @@ program
       }
     }
   );
+
+program
+  .command("organize")
+  .description("Analyze card network: orphans, hubs, conflicts, and contradiction pairs")
+  .option("--since <date>", "Only check cards modified since this date (YYYY-MM-DD)")
+  .option("--nested", "Use nested (path-preserving) slugs for this command")
+  .action(async (opts: { since?: string; nested?: boolean }) => {
+    const store = await getStore({ nested: opts.nested });
+    const result = await organizeCommand(store, opts.since ?? null);
+    if (result.output) process.stdout.write(result.output + "\n");
+    process.exit(result.exitCode);
+  });
 
 program
   .command("mcp")


### PR DESCRIPTION
## Problem

`memex organize` fails with `error: unknown command 'organize', breaking both CLI users and the Pi extension's `memex_organize` tool (which routes through the CLI via `spawn`).

Closes #49

## Root Cause

`src/commands/organize.ts` exists and is correctly used by the MCP server (`src/mcp/operations.ts`), but was never imported or registered with Commander in `src/cli.ts`.

## Fix

Two additions to `src/cli.ts`:

1. **Import**: `import { organizeCommand } from "./commands/organize.js"`
2. **Command registration**: new `.command("organize")` block with `--since` and `--nested` options, following the same pattern as every other command

## Verification

- `npx tsc --noEmit` passes with zero errors
- `memex organize` now returns a proper organize report (link stats, orphans, hubs, contradictions)
- `memex --help` lists the organize command

```diff
+ import { organizeCommand } from "./commands/organize.js";

+ program
+   .command("organize")
+   .description("Analyze card network: orphans, hubs, conflicts, and contradiction pairs")
+   .option("--since <date>", "Only check cards modified since this date (YYYY-MM-DD)")
+   .option("--nested", "Use nested (path-preserving) slugs for this command")
+   .action(async (opts) => {
+     const store = await getStore({ nested: opts.nested });
+     const result = await organizeCommand(store, opts.since ?? null);
+     if (result.output) process.stdout.write(result.output + "\n");
+     process.exit(result.exitCode);
+   });
```