### PR TITLE
fix(ci): resolve Windows test timeout and Node.js 24 upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [20, 22]
+        node: [22, 24]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -67,7 +67,7 @@ describe("syncCommand", () => {
     const result = await syncCommand(home, { action: "push" });
     expect(result.success).toBe(true);
     expect(result.output).toContain("Pushed");
-  });
+  }, 20000);
 
   it("pull after init succeeds", async () => {
     await syncCommand(home, { init: true, remote: bare });
@@ -98,5 +98,5 @@ describe("syncCommand", () => {
     const result = await syncCommand(home, { init: true, remote: bare });
     expect(result.success).toBe(true);
     expect(result.output).toContain("Sync initialized");
-  });
+  }, 20000);
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    testTimeout: 15000, // Increase timeout for Windows git operations
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## 修复内容

**解决issue #62中的CI失败问题**

### 🐛 修复的问题
1. **Windows测试超时**：2个sync测试在Windows环境下超过5秒默认超时
2. **Node.js 20弃用警告**：GitHub Actions需要升级以支持Node.js 24

### 🔧 具体修改
1. **升级GitHub Actions**：
   -  → 
   -  → 
   - 添加  环境变量

2. **测试超时优化**：
   - vitest默认超时：5秒 → 15秒
   - 失败的两个sync测试：明确设置20秒超时
   - Windows环境git操作需要更多时间

3. **Node.js版本矩阵**：
   - 从  更新到 
   - 提前适配Node.js 24（2026年6月强制要求）

### ✅ 验证
- 本地测试通过
- 修复针对具体失败的测试用例
- 低风险基础设施改进

Closes #62