### PR TITLE
fix(test): increase timeout for Windows embedding tests to 5min

### DIFF
--- a/tests/lib/local-embeddings.test.ts
+++ b/tests/lib/local-embeddings.test.ts
@@ -191,7 +191,7 @@ describe("LocalEmbeddingProvider", () => {
     // Should be normalized (unit vector)
     const magnitude = Math.sqrt(result[0].reduce((sum, v) => sum + v * v, 0));
     expect(magnitude).toBeCloseTo(1, 2);
-  }, 60000); // 60s timeout for model loading
+  }, 300000); // 5 min — model download + loading is slow on Windows CI
 
   it("generates different embeddings for different texts", async () => {
     const provider = new LocalEmbeddingProvider();
@@ -199,7 +199,7 @@ describe("LocalEmbeddingProvider", () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]).not.toEqual(result[1]);
-  }, 60000);
+  }, 300000); // 5 min — consistent with other embedding tests
 
   it("generates consistent embeddings for the same text", async () => {
     const provider = new LocalEmbeddingProvider();
@@ -208,7 +208,7 @@ describe("LocalEmbeddingProvider", () => {
 
     // Vectors should be identical
     expect(v1).toEqual(v2);
-  }, 60000);
+  }, 300000); // 5 min — consistent with other embedding tests
 
   it("handles long text that exceeds context size without error", async () => {
     const provider = new LocalEmbeddingProvider();


### PR DESCRIPTION
## 问题

PR #63 merge后在Windows Node.js 22环境下CI失败，原因是embedding测试超时（60秒）。

## 原因分析

测试需要下载328MB的embedding模型，Windows环境下下载和加载速度较慢，60秒超时不足。

## 修复

将embedding测试超时统一为300秒（5分钟），与已有的长时间测试保持一致。

## 测试计划

等待CI运行完成，验证Windows Node.js 22测试通过。
