### PR TITLE
fix: Windows browser auto-open fails in serve command

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -66,7 +66,7 @@ export async function serveCommand(port: number): Promise<Server | null> {
       const bin = process.platform === "darwin" ? "open"
         : process.platform === "win32" ? "start"
         : "xdg-open";
-      execFile(bin, [MEMRA_URL], () => {});
+      execFile(bin, [MEMRA_URL], { shell: process.platform === "win32" }, () => {});
     }
     return null;
   }
@@ -225,7 +225,7 @@ export async function serveCommand(port: number): Promise<Server | null> {
           const bin = process.platform === "darwin" ? "open"
             : process.platform === "win32" ? "start"
             : "xdg-open";
-          execFile(bin, [url], () => {});
+          execFile(bin, [url], { shell: process.platform === "win32" }, () => {});
         }
         resolvePromise(server);
       });


### PR DESCRIPTION
  ## Summary

  - `execFile("start", [url])` silently fails on Windows because `start` is a `cmd.exe` built-in command, not a standalone executable
  - Fix: add `{ shell: process.platform === "win32" }` — enables shell on Windows, no-op (`false`) on macOS/Linux
  - Two call sites in `src/commands/serve.ts` (lines 69 and 228)

  ## Reproduce

  On Windows:
  ```bash
  memex serve
  # Server starts on http://localhost:3939 but browser does NOT open
  ```

  ## Root Cause

  `child_process.execFile` searches PATH for an executable file. `start` is not a file — it's built into `cmd.exe`. Without `{ shell: true }`, Node can't find it and the error is
  silently swallowed by the empty callback `() => {}`.

  ## Test plan

  - [x] `npm test` — 472 tests pass, no regressions
  - [x] Verified on Windows: browser now opens automatically
  - [ ] macOS/Linux: `{ shell: false }` equals default behavior, no impact

  Fixes #6