### PR TITLE
fix(sync): normalize branch name in init to prevent cross-platform divergence (fixes #67)

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -214,6 +214,12 @@ export class GitAdapter implements SyncAdapter {
     // Fetch remote — if it has existing commits, merge them before pushing
     try {
       await execFile("git", ["-C", this.home, "fetch", "origin"]);
+
+      // Normalize local branch to match remote default branch.
+      // Without this, machines with different git init.defaultBranch settings
+      // (e.g. main vs master) create divergent branches on the same remote.
+      await this.normalizeBranch();
+
       // Check if remote has any commits
       try {
         const remoteBranch = await detectRemoteBranch(this.home);
@@ -236,6 +242,41 @@ export class GitAdapter implements SyncAdapter {
       adapter: "git",
       auto: false,
     });
+  }
+
+  /**
+   * Rename the local branch to match the remote's default branch,
+   * or fall back to "main" if the remote is empty.
+   */
+  private async normalizeBranch(): Promise<void> {
+    let target = "main"; // fallback for empty remotes
+
+    // Detect remote's default branch via ls-remote --symref
+    try {
+      const { stdout } = await execFile("git", [
+        "-C", this.home, "ls-remote", "--symref", "origin", "HEAD",
+      ]);
+      // Parses: "ref: refs/heads/<branch>\tHEAD"
+      const match = stdout.match(/ref: refs\/heads\/(\S+)\s/);
+      if (match) {
+        target = match[1];
+      }
+    } catch {
+      // ls-remote failed (empty remote or offline) — use fallback
+    }
+
+    // Get current local branch name
+    try {
+      const { stdout } = await execFile("git", [
+        "-C", this.home, "rev-parse", "--abbrev-ref", "HEAD",
+      ]);
+      const current = stdout.trim();
+      if (current && current !== target) {
+        await execFile("git", ["-C", this.home, "branch", "-M", target]);
+      }
+    } catch {
+      // No commits yet or detached HEAD — branch -M will work after first commit
+    }
   }
 
   async pull(): Promise<SyncResult> {

--- a/tests/lib/sync.test.ts
+++ b/tests/lib/sync.test.ts
@@ -61,6 +61,8 @@ describe("GitAdapter", () => {
   async function createBareRemote(): Promise<string> {
     const bare = await mkdtemp(join(tmpdir(), "memex-bare-"));
     await execFile("git", ["init", "--bare", bare]);
+    // Ensure HEAD points to main so clones check out the right branch
+    await execFile("git", ["-C", bare, "symbolic-ref", "HEAD", "refs/heads/main"]);
     return bare;
   }
 
@@ -276,6 +278,55 @@ describe("GitAdapter", () => {
     const adapter = new GitAdapter(home);
     await expect(adapter.init("../traversal")).rejects.toThrow("Invalid remote URL");
   });
+
+  it("init normalizes local branch to match remote default (master → main)", async () => {
+    // Create a bare remote with 'main' as its branch
+    const bare = await mkdtemp(join(tmpdir(), "memex-bare-"));
+    await execFile("git", ["init", "--bare", bare]);
+    // Push a dummy commit to establish 'main' on the remote
+    const seed = await mkdtemp(join(tmpdir(), "memex-seed-"));
+    await execFile("git", ["init", seed]);
+    await execFile("git", ["-C", seed, "checkout", "-b", "main"]);
+    await writeFile(join(seed, "README.md"), "seed", "utf-8");
+    await execFile("git", ["-C", seed, "add", "."]);
+    await execFile("git", ["-C", seed, "commit", "-m", "seed"]);
+    await execFile("git", ["-C", seed, "remote", "add", "origin", bare]);
+    await execFile("git", ["-C", seed, "push", "-u", "origin", "main"]);
+    // Set HEAD on bare to refs/heads/main
+    await execFile("git", ["-C", bare, "symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    // Now init local repo on 'master' (simulating old git default)
+    await execFile("git", ["init", home]);
+    await execFile("git", ["-C", home, "checkout", "-b", "master"]);
+
+    const adapter = new GitAdapter(home);
+    await adapter.init(bare);
+
+    // Local branch should now be 'main', not 'master'
+    const { stdout } = await execFile("git", ["-C", home, "rev-parse", "--abbrev-ref", "HEAD"]);
+    expect(stdout.trim()).toBe("main");
+
+    await rm(bare, { recursive: true });
+    await rm(seed, { recursive: true });
+  }, 20000);
+
+  it("init normalizes local branch to 'main' when remote is empty", async () => {
+    const bare = await mkdtemp(join(tmpdir(), "memex-bare-"));
+    await execFile("git", ["init", "--bare", bare]);
+
+    // Init local repo on 'master'
+    await execFile("git", ["init", home]);
+    await execFile("git", ["-C", home, "checkout", "-b", "master"]);
+
+    const adapter = new GitAdapter(home);
+    await adapter.init(bare);
+
+    // Should be normalized to 'main'
+    const { stdout } = await execFile("git", ["-C", home, "rev-parse", "--abbrev-ref", "HEAD"]);
+    expect(stdout.trim()).toBe("main");
+
+    await rm(bare, { recursive: true });
+  }, 15000);
 
   it("init accepts git@... SSH URL (validation only)", async () => {
     // Verify URL validation passes — init will fail on push (no real remote), that's OK


### PR DESCRIPTION
## Problem

`sync --init` on two machines with different `init.defaultBranch` git configs (e.g. macOS defaults to `main`, older Windows to `master`) creates divergent branches on the same remote. Both machines push to different branch names and cards diverge silently.

## Fix

After `git fetch origin` in `init()`, detect the remote's default branch via `git ls-remote --symref origin HEAD` and rename the local branch to match using `git branch -M`. Falls back to `main` for empty remotes.

Added as a private `normalizeBranch()` method on `GitAdapter`.

## Tests

Added 2 new test cases in `tests/lib/sync.test.ts`:
- `init normalizes local branch to match remote default (master → main)` — verifies local `master` gets renamed to `main` when remote HEAD points to `main`
- `init normalizes local branch to 'main' when remote is empty` — verifies fallback for fresh repos

All 23 sync tests pass.

Fixes #67