### PR TITLE
feat(links): add --filter and --stats options for link analysis

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,9 +106,12 @@ program
 program
   .command("links [slug]")
   .description("Show link graph stats or specific card links")
-  .action(async (slug?: string) => {
+  .option("--filter <type>", "Filter cards: orphan or hub")
+  .option("--stats", "Show summary statistics instead of card list")
+  .action(async (slug?: string, cmdOpts?: { filter?: string; stats?: boolean }) => {
     const store = await getStore();
-    const result = await linksCommand(store, slug);
+    const filter = cmdOpts?.filter as "orphan" | "hub" | undefined;
+    const result = await linksCommand(store, slug, { filter, stats: cmdOpts?.stats });
     if (result.output) process.stdout.write(result.output + "\n");
     exit(result.exitCode);
   });

--- a/src/commands/links.ts
+++ b/src/commands/links.ts
@@ -1,13 +1,20 @@
 import { CardStore } from "../lib/store.js";
 import { parseFrontmatter, extractLinks } from "../lib/parser.js";
-import { formatLinkStats, formatCardLinks } from "../lib/formatter.js";
+import { formatLinkStats, formatCardLinks, LinkStatsItem } from "../lib/formatter.js";
+
+const HUB_THRESHOLD = 10;
 
 interface LinksResult {
   output: string;
   exitCode: number;
 }
 
-export async function linksCommand(store: CardStore, slug: string | undefined): Promise<LinksResult> {
+export interface LinksOptions {
+  filter?: "orphan" | "hub";
+  stats?: boolean;
+}
+
+export async function linksCommand(store: CardStore, slug: string | undefined, opts?: LinksOptions): Promise<LinksResult> {
   const cards = await store.scanAll();
   if (cards.length === 0) return { output: "", exitCode: 0 };
 
@@ -37,11 +44,44 @@ export async function linksCommand(store: CardStore, slug: string | undefined): 
     return { output: formatCardLinks(slug, outbound, inbound), exitCode: 0 };
   }
 
-  const stats = cards.map((card) => ({
+  let stats: LinkStatsItem[] = cards.map((card) => ({
     slug: card.slug,
     outbound: (outboundMap.get(card.slug) || []).length,
     inbound: (inboundMap.get(card.slug) || []).length,
   }));
 
+  const filter = opts?.filter;
+  if (filter === "orphan") {
+    stats = stats.filter((s) => s.inbound === 0);
+  } else if (filter === "hub") {
+    stats = stats.filter((s) => s.inbound >= HUB_THRESHOLD);
+  }
+
+  if (opts?.stats) {
+    return { output: formatLinkSummary(stats, cards.length, filter), exitCode: 0 };
+  }
+
   return { output: formatLinkStats(stats), exitCode: 0 };
+}
+
+function formatLinkSummary(stats: LinkStatsItem[], totalCards: number, filter?: string): string {
+  const orphans = stats.filter((s) => s.inbound === 0).length;
+  const hubs = stats.filter((s) => s.inbound >= HUB_THRESHOLD).length;
+  const totalOut = stats.reduce((sum, s) => sum + s.outbound, 0);
+  const totalIn = stats.reduce((sum, s) => sum + s.inbound, 0);
+  const avgOut = stats.length > 0 ? (totalOut / stats.length).toFixed(1) : "0";
+  const avgIn = stats.length > 0 ? (totalIn / stats.length).toFixed(1) : "0";
+
+  const lines: string[] = [];
+  if (filter) {
+    lines.push(`Showing: ${filter} (${stats.length} cards)`);
+    lines.push(`Total cards: ${totalCards}`);
+  } else {
+    lines.push(`Total cards: ${totalCards}`);
+  }
+  lines.push(`Orphans (0 inbound): ${orphans}`);
+  lines.push(`Hubs (${HUB_THRESHOLD}+ inbound): ${hubs}`);
+  lines.push(`Avg outbound links: ${avgOut}`);
+  lines.push(`Avg inbound links: ${avgIn}`);
+  return lines.join("\n");
 }

--- a/tests/commands/links.test.ts
+++ b/tests/commands/links.test.ts
@@ -46,4 +46,32 @@ describe("linksCommand", () => {
     const result = await linksCommand(store, undefined);
     expect(result.output).toContain("orphan");
   });
+
+  it("filters to orphans only", async () => {
+    await writeFile(join(tmpDir, "cards", "orphan.md"), "---\ntitle: Orphan\n---\nNo one links here.");
+    const result = await linksCommand(store, undefined, { filter: "orphan" });
+    // a has 1 inbound (from b), b has 1 inbound (from a), c has 1 inbound (from a)
+    // orphan has 0 inbound → should appear
+    expect(result.output).toContain("orphan");
+    // a, b, c all have inbound links → should NOT appear
+    expect(result.output).not.toMatch(/^a\s/m);
+    expect(result.output).not.toMatch(/^b\s/m);
+    expect(result.output).not.toMatch(/^c\s/m);
+  });
+
+  it("shows summary stats", async () => {
+    const result = await linksCommand(store, undefined, { stats: true });
+    expect(result.output).toContain("Total cards: 3");
+    expect(result.output).toContain("Orphans (0 inbound):");
+    expect(result.output).toContain("Hubs (10+ inbound):");
+    expect(result.output).toContain("Avg outbound links:");
+    expect(result.output).toContain("Avg inbound links:");
+  });
+
+  it("combines filter and stats", async () => {
+    await writeFile(join(tmpDir, "cards", "orphan.md"), "---\ntitle: Orphan\n---\nNo one links here.");
+    const result = await linksCommand(store, undefined, { filter: "orphan", stats: true });
+    expect(result.output).toContain("Showing: orphan");
+    expect(result.output).toContain("Total cards: 4");
+  });
 });


### PR DESCRIPTION
## Problem

With 100+ knowledge cards, `memex links` output is overwhelming — users have to pipe through `grep orphan` to find disconnected cards or manually count statistics.

## Solution

Add two new options to `memex links`:

- **`--filter orphan`** — show only cards with 0 inbound links
- **`--filter hub`** — show only cards with 10+ inbound links  
- **`--stats`** — show summary statistics instead of the full card list

Options can be combined: `memex links --filter orphan --stats` shows stats scoped to orphans only.

### Examples

```bash
# List only orphan cards
memex links --filter orphan

# Quick health summary
memex links --stats
# Total cards: 196
# Orphans (0 inbound): 52
# Hubs (10+ inbound): 3
# Avg outbound links: 3.2
# Avg inbound links: 2.8

# Orphan summary
memex links --filter orphan --stats
# Showing: orphan (52 cards)
# Total cards: 196
# ...
```

## Changes

- `src/commands/links.ts` — accept `LinksOptions` with filter/stats, add `formatLinkSummary`
- `src/cli.ts` — wire up `--filter` and `--stats` CLI options
- `tests/commands/links.test.ts` — 3 new test cases (6 total, all passing)

## Testing

```
npx vitest run tests/commands/links.test.ts
# ✓ 6 tests passed
npx tsc --noEmit  # clean
```

Motivated by daily dogfooding with a 196-card wiki.