### PR TITLE
feat(doctor): run all health checks by default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import { archiveCommand } from "./commands/archive.js";
 import { serveCommand } from "./commands/serve.js";
 import { syncCommand } from "./commands/sync.js";
 import { importCommand } from "./commands/import.js";
-import { doctorCommand } from "./commands/doctor.js";
+import { doctorCommand, doctorRunAll } from "./commands/doctor.js";
 import { migrateCommand } from "./commands/migrate.js";
 import { backlinksCommand } from "./commands/backlinks.js";
 import { organizeCommand } from "./commands/organize.js";
@@ -264,8 +264,9 @@ program
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     } else {
-      process.stderr.write("No check specified. Use --check-collisions to check for slug collisions.\n");
-      exit(1);
+      const result = await doctorRunAll(cardsDir, archiveDir);
+      if (result.output) process.stdout.write(result.output + "\n");
+      exit(result.exitCode);
     }
   });
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,8 +1,15 @@
 import { CardStore } from "../lib/store.js";
+import { parseFrontmatter, extractLinks } from "../lib/parser.js";
 
-interface DoctorResult {
+export interface DoctorResult {
   exitCode: number;
   output?: string;
+}
+
+export interface CheckResult {
+  name: string;
+  status: "ok" | "warn" | "error";
+  message: string;
 }
 
 interface CollisionGroup {
@@ -11,16 +18,14 @@ interface CollisionGroup {
   fullPaths: string[];
 }
 
-export async function doctorCommand(
+export async function checkCollisions(
   cardsDir: string,
   archiveDir: string
-): Promise<DoctorResult> {
+): Promise<CheckResult> {
   try {
-    // Scan with basename mode (nestedSlugs=false) to find collisions
     const basenameStore = new CardStore(cardsDir, archiveDir, false);
     const cards = await basenameStore.scanAll();
 
-    // Group by slug to find collisions
     const slugMap = new Map<string, string[]>();
     for (const card of cards) {
       if (!slugMap.has(card.slug)) {
@@ -29,18 +34,179 @@ export async function doctorCommand(
       slugMap.get(card.slug)!.push(card.path);
     }
 
-    // Find collision groups (slugs with multiple paths)
     const collisions: CollisionGroup[] = [];
     for (const [slug, paths] of slugMap.entries()) {
       if (paths.length > 1) {
-        // Get full paths using nested mode
         const nestedStore = new CardStore(cardsDir, archiveDir, true);
         const nestedCards = await nestedStore.scanAll();
         const fullPaths = paths.map((path) => {
           const found = nestedCards.find((c) => c.path === path);
           return found?.slug ?? path;
         });
+        collisions.push({ slug, paths, fullPaths });
+      }
+    }
 
+    if (collisions.length === 0) {
+      return {
+        name: "Slug collisions",
+        status: "ok",
+        message: "none found",
+      };
+    }
+
+    const details = collisions
+      .map((c) => `  "${c.slug}" → ${c.paths.join(", ")}`)
+      .join("\n");
+    return {
+      name: "Slug collisions",
+      status: "error",
+      message: `${collisions.length} collision(s) found\n${details}`,
+    };
+  } catch (e) {
+    return {
+      name: "Slug collisions",
+      status: "error",
+      message: `check failed: ${(e as Error).message}`,
+    };
+  }
+}
+
+export async function checkOrphans(
+  cardsDir: string,
+  archiveDir: string
+): Promise<CheckResult> {
+  try {
+    const store = new CardStore(cardsDir, archiveDir, true);
+    const cards = await store.scanAll();
+    if (cards.length === 0) {
+      return { name: "Orphans", status: "ok", message: "no cards found" };
+    }
+
+    const inboundMap = new Map<string, number>();
+    for (const card of cards) {
+      inboundMap.set(card.slug, 0);
+    }
+
+    for (const card of cards) {
+      const raw = await store.readCard(card.slug);
+      const { content } = parseFrontmatter(raw);
+      const links = extractLinks(content);
+      for (const link of links) {
+        if (inboundMap.has(link)) {
+          inboundMap.set(link, (inboundMap.get(link) || 0) + 1);
+        }
+      }
+    }
+
+    const orphans = Array.from(inboundMap.entries())
+      .filter(([, count]) => count === 0)
+      .map(([slug]) => slug);
+
+    if (orphans.length === 0) {
+      return { name: "Orphans", status: "ok", message: "all cards have inbound links" };
+    }
+
+    const pct = ((orphans.length / cards.length) * 100).toFixed(0);
+    return {
+      name: "Orphans",
+      status: "warn",
+      message: `${orphans.length} cards (${pct}%) have no inbound links`,
+    };
+  } catch (e) {
+    return {
+      name: "Orphans",
+      status: "error",
+      message: `check failed: ${(e as Error).message}`,
+    };
+  }
+}
+
+export async function checkBrokenLinks(
+  cardsDir: string,
+  archiveDir: string
+): Promise<CheckResult> {
+  try {
+    const store = new CardStore(cardsDir, archiveDir, true);
+    const cards = await store.scanAll();
+    const knownSlugs = new Set(cards.map((c) => c.slug));
+    const broken: { from: string; to: string }[] = [];
+
+    for (const card of cards) {
+      const raw = await store.readCard(card.slug);
+      const { content } = parseFrontmatter(raw);
+      const links = extractLinks(content);
+      for (const link of links) {
+        if (!knownSlugs.has(link)) {
+          broken.push({ from: card.slug, to: link });
+        }
+      }
+    }
+
+    if (broken.length === 0) {
+      return { name: "Broken links", status: "ok", message: "none found" };
+    }
+
+    return {
+      name: "Broken links",
+      status: "warn",
+      message: `${broken.length} link(s) to non-existent cards`,
+    };
+  } catch (e) {
+    return {
+      name: "Broken links",
+      status: "error",
+      message: `check failed: ${(e as Error).message}`,
+    };
+  }
+}
+
+function formatCheckResult(r: CheckResult): string {
+  const icon = r.status === "ok" ? "✓" : r.status === "warn" ? "⚠" : "✗";
+  return `${icon} ${r.name}: ${r.message}`;
+}
+
+export async function doctorRunAll(
+  cardsDir: string,
+  archiveDir: string
+): Promise<DoctorResult> {
+  const results = await Promise.all([
+    checkCollisions(cardsDir, archiveDir),
+    checkOrphans(cardsDir, archiveDir),
+    checkBrokenLinks(cardsDir, archiveDir),
+  ]);
+
+  const output = results.map(formatCheckResult).join("\n");
+  const hasError = results.some((r) => r.status === "error");
+  return { exitCode: hasError ? 1 : 0, output };
+}
+
+/** Legacy entry point for backward compat (collision check only) — preserves original output format */
+export async function doctorCommand(
+  cardsDir: string,
+  archiveDir: string
+): Promise<DoctorResult> {
+  try {
+    const basenameStore = new CardStore(cardsDir, archiveDir, false);
+    const cards = await basenameStore.scanAll();
+
+    const slugMap = new Map<string, string[]>();
+    for (const card of cards) {
+      if (!slugMap.has(card.slug)) {
+        slugMap.set(card.slug, []);
+      }
+      slugMap.get(card.slug)!.push(card.path);
+    }
+
+    const collisions: CollisionGroup[] = [];
+    for (const [slug, paths] of slugMap.entries()) {
+      if (paths.length > 1) {
+        const nestedStore = new CardStore(cardsDir, archiveDir, true);
+        const nestedCards = await nestedStore.scanAll();
+        const fullPaths = paths.map((path) => {
+          const found = nestedCards.find((c) => c.path === path);
+          return found?.slug ?? path;
+        });
         collisions.push({ slug, paths, fullPaths });
       }
     }
@@ -52,7 +218,6 @@ export async function doctorCommand(
       };
     }
 
-    // Build collision report
     const lines: string[] = [`Found ${collisions.length} slug collision(s):\n`];
     for (const collision of collisions) {
       lines.push(`Slug "${collision.slug}" collides:`);
@@ -64,10 +229,7 @@ export async function doctorCommand(
     }
     lines.push("Resolve these collisions before enabling nestedSlugs.");
 
-    return {
-      exitCode: 1,
-      output: lines.join("\n"),
-    };
+    return { exitCode: 1, output: lines.join("\n") };
   } catch (e) {
     return {
       exitCode: 1,

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { doctorCommand } from "../../src/commands/doctor.js";
+import {
+  doctorCommand,
+  doctorRunAll,
+  checkCollisions,
+  checkOrphans,
+  checkBrokenLinks,
+} from "../../src/commands/doctor.js";
 
-describe("doctorCommand", () => {
+describe("doctorCommand (legacy collision check)", () => {
   let tmpDir: string;
   let cardsDir: string;
   let archiveDir: string;
@@ -67,5 +73,132 @@ describe("doctorCommand", () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("would become: card");
     expect(result.output).toContain("would become: nested/deep/card");
+  });
+});
+
+describe("checkOrphans", () => {
+  let tmpDir: string;
+  let cardsDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-"));
+    cardsDir = join(tmpDir, "cards");
+    archiveDir = join(tmpDir, "archive");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports ok when all cards have inbound links", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await checkOrphans(cardsDir, archiveDir);
+    expect(result.status).toBe("ok");
+  });
+
+  it("detects orphan cards with no inbound links", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "no links");
+    await writeFile(join(cardsDir, "c.md"), "also no links");
+
+    const result = await checkOrphans(cardsDir, archiveDir);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("2 cards");
+    expect(result.message).toContain("no inbound links");
+  });
+
+  it("reports ok for empty wiki", async () => {
+    const result = await checkOrphans(cardsDir, archiveDir);
+    expect(result.status).toBe("ok");
+  });
+});
+
+describe("checkBrokenLinks", () => {
+  let tmpDir: string;
+  let cardsDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-"));
+    cardsDir = join(tmpDir, "cards");
+    archiveDir = join(tmpDir, "archive");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports ok when all links resolve", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "exists");
+
+    const result = await checkBrokenLinks(cardsDir, archiveDir);
+    expect(result.status).toBe("ok");
+  });
+
+  it("detects links to non-existent cards", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[missing]] and [[also-missing]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await checkBrokenLinks(cardsDir, archiveDir);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("2 link(s) to non-existent cards");
+  });
+});
+
+describe("doctorRunAll", () => {
+  let tmpDir: string;
+  let cardsDir: string;
+  let archiveDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-test-"));
+    cardsDir = join(tmpDir, "cards");
+    archiveDir = join(tmpDir, "archive");
+    await mkdir(cardsDir, { recursive: true });
+    await mkdir(archiveDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns exit 0 for a healthy wiki", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await doctorRunAll(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("✓ Slug collisions");
+    expect(result.output).toContain("✓ Orphans");
+    expect(result.output).toContain("✓ Broken links");
+  });
+
+  it("returns exit 0 even with warnings", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "no links");
+    await writeFile(join(cardsDir, "c.md"), "also no links, links to [[missing]]");
+
+    const result = await doctorRunAll(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("⚠ Orphans");
+    expect(result.output).toContain("⚠ Broken links");
+  });
+
+  it("returns exit 1 when collisions exist", async () => {
+    await mkdir(join(cardsDir, "sub"), { recursive: true });
+    await writeFile(join(cardsDir, "x.md"), "root");
+    await writeFile(join(cardsDir, "sub", "x.md"), "sub");
+
+    const result = await doctorRunAll(cardsDir, archiveDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("✗ Slug collisions");
   });
 });


### PR DESCRIPTION
## Problem

`memex doctor` with no flags prints "No check specified" and exits with code 1. Users expect a doctor command to run all checks by default.

## Solution

When run without flags, `memex doctor` now executes all available health checks:

- **Slug collisions** — existing check, detects basename conflicts
- **Orphan detection** — finds cards with no inbound wikilinks
- **Broken link detection** — finds wikilinks pointing to non-existent cards

Output uses visual indicators:
```
✓ Slug collisions: none found
⚠ Orphans: 51 cards (25%) have no inbound links
✓ Broken links: none found
```

Exit code 0 unless errors (collisions) are found. Warnings (orphans, broken links) don't fail.

The `--check-collisions` flag still works for backward compatibility.

## Changes

- `src/commands/doctor.ts` — Added `checkOrphans`, `checkBrokenLinks`, and `doctorRunAll` functions. Preserved legacy `doctorCommand` for backward compat.
- `src/cli.ts` — Default to `doctorRunAll` when no flag specified
- `tests/commands/doctor.test.ts` — Added 8 new tests (orphan detection, broken links, run-all scenarios). All 12 tests pass.

## Testing

```bash
npx vitest run tests/commands/doctor.test.ts  # 12 tests pass
```