### PR TITLE
feat(doctor): add --verbose flag to show broken link and orphan details

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,7 +254,8 @@ program
   .command("doctor")
   .description("Check memex health and configuration")
   .option("--check-collisions", "Check for slug collisions in basename mode")
-  .action(async (opts: { checkCollisions?: boolean }) => {
+  .option("--verbose", "Show detailed output for warnings")
+  .action(async (opts: { checkCollisions?: boolean; verbose?: boolean }) => {
     const home = await resolveMemexHome();
     const cardsDir = join(home, "cards");
     const archiveDir = join(home, "archive");
@@ -264,7 +265,7 @@ program
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     } else {
-      const result = await doctorRunAll(cardsDir, archiveDir);
+      const result = await doctorRunAll(cardsDir, archiveDir, opts.verbose);
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -74,7 +74,8 @@ export async function checkCollisions(
 
 export async function checkOrphans(
   cardsDir: string,
-  archiveDir: string
+  archiveDir: string,
+  verbose?: boolean
 ): Promise<CheckResult> {
   try {
     const store = new CardStore(cardsDir, archiveDir, true);
@@ -108,10 +109,14 @@ export async function checkOrphans(
     }
 
     const pct = ((orphans.length / cards.length) * 100).toFixed(0);
+    let message = `${orphans.length} cards (${pct}%) have no inbound links`;
+    if (verbose) {
+      message += "\n" + orphans.map((s) => `  ${s}`).join("\n");
+    }
     return {
       name: "Orphans",
       status: "warn",
-      message: `${orphans.length} cards (${pct}%) have no inbound links`,
+      message,
     };
   } catch (e) {
     return {
@@ -124,7 +129,8 @@ export async function checkOrphans(
 
 export async function checkBrokenLinks(
   cardsDir: string,
-  archiveDir: string
+  archiveDir: string,
+  verbose?: boolean
 ): Promise<CheckResult> {
   try {
     const store = new CardStore(cardsDir, archiveDir, true);
@@ -147,10 +153,16 @@ export async function checkBrokenLinks(
       return { name: "Broken links", status: "ok", message: "none found" };
     }
 
+    let message = `${broken.length} link(s) to non-existent cards`;
+    if (verbose) {
+      const details = broken.map((b) => `  ${b.from} → ${b.to}`).join("\n");
+      message += "\n" + details;
+    }
+
     return {
       name: "Broken links",
       status: "warn",
-      message: `${broken.length} link(s) to non-existent cards`,
+      message,
     };
   } catch (e) {
     return {
@@ -168,12 +180,13 @@ function formatCheckResult(r: CheckResult): string {
 
 export async function doctorRunAll(
   cardsDir: string,
-  archiveDir: string
+  archiveDir: string,
+  verbose?: boolean
 ): Promise<DoctorResult> {
   const results = await Promise.all([
     checkCollisions(cardsDir, archiveDir),
-    checkOrphans(cardsDir, archiveDir),
-    checkBrokenLinks(cardsDir, archiveDir),
+    checkOrphans(cardsDir, archiveDir, verbose),
+    checkBrokenLinks(cardsDir, archiveDir, verbose),
   ]);
 
   const output = results.map(formatCheckResult).join("\n");

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -112,6 +112,17 @@ describe("checkOrphans", () => {
     expect(result.message).toContain("no inbound links");
   });
 
+  it("lists orphan slugs in verbose mode", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "no links");
+    await writeFile(join(cardsDir, "c.md"), "also no links");
+
+    const result = await checkOrphans(cardsDir, archiveDir, true);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("  a");
+    expect(result.message).toContain("  c");
+  });
+
   it("reports ok for empty wiki", async () => {
     const result = await checkOrphans(cardsDir, archiveDir);
     expect(result.status).toBe("ok");
@@ -150,6 +161,24 @@ describe("checkBrokenLinks", () => {
     const result = await checkBrokenLinks(cardsDir, archiveDir);
     expect(result.status).toBe("warn");
     expect(result.message).toContain("2 link(s) to non-existent cards");
+  });
+
+  it("shows details in verbose mode", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[missing]] and [[also-missing]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await checkBrokenLinks(cardsDir, archiveDir, true);
+    expect(result.status).toBe("warn");
+    expect(result.message).toContain("a \u2192 missing");
+    expect(result.message).toContain("a \u2192 also-missing");
+  });
+
+  it("omits details without verbose", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[missing]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await checkBrokenLinks(cardsDir, archiveDir, false);
+    expect(result.message).not.toContain("\u2192");
   });
 });
 


### PR DESCRIPTION
## Summary

When `memex doctor` reports warnings for orphans or broken links, users currently only see the count. With `--verbose`, the actual slugs and broken link pairs are listed, making the output immediately actionable.

### Before
```
⚠ Orphans: 51 cards (25%) have no inbound links
⚠ Broken links: 247 link(s) to non-existent cards
```

### After (`--verbose`)
```
⚠ Orphans: 51 cards (25%) have no inbound links
  INDEX
  action-authorization-vs-context-integrity
  agent-human-collaboration-product
  ...
⚠ Broken links: 247 link(s) to non-existent cards
  acp → openclaw
  agent-as-router → gitclaw
  agent-brain-portability → agentic-stack
  ...
```

## Changes
- Add `verbose?: boolean` parameter to `checkOrphans()` and `checkBrokenLinks()`
- Pass `--verbose` CLI option through `doctorRunAll()`
- Add 3 new tests for verbose output behavior

## Testing
- All 15 doctor tests pass (12 existing + 3 new)
- Verified on a real wiki with 201 cards, 51 orphans, 247 broken links

Closes #75