### PR TITLE
fix: resolve pi-extension entry to index.ts so tools register correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "pi": {
     "extensions": [
-      "pi-extension"
+      "pi-extension/index.ts"
     ]
   },
   "license": "MIT",


### PR DESCRIPTION
## Problem

`package.json` declares `"pi": { "extensions": ["pi-extension"] }`. The pi extension loader (`resolveExtensionEntries` in `loader.js`) resolves this entry against the package root via `path.resolve(dir, "pi-extension")`, which yields the **directory** path `.../memex/pi-extension` — not a file.

This directory path is then passed to jiti via `jiti.import(dirPath)`. jiti follows standard Node.js directory resolution: looks for `package.json` → `main`, then `index.js`. The `pi-extension/` directory has only `index.ts` (no `index.js` and no `package.json`), so jiti cannot resolve it and throws an error. That error is silently caught inside `loadExtension()`:

```js
} catch (err) {
  const message = err instanceof Error ? err.message : String(err);
  return { extension: null, error: `Failed to load extension: ${message}` };
}
```

The extension is never loaded, so **none of the tools** (`memex_recall`, `memex_retro`, `memex_search`, `memex_read`, `memex_write`, `memex_links`, `memex_archive`, `memex_organize`) are registered in the pi tool registry. Users see the memex skill injected into their system prompt but cannot actually call any memex tools.

## Root Cause

| Package | `pi.extensions` entry | Resolved to | Works? |
|---|---|---|---|
| `@sting8k/pi-vcc` | `"./index.ts"` | explicit `.ts` file | ✅ |
| `@touchskyer/memex` | `"pi-extension"` | directory (no `index.js`) | ❌ |

## Fix

Change the entry from the directory name to the explicit file path:

```diff
- "pi-extension"
+ "pi-extension/index.ts"
```

This passes an explicit `.ts` file path to jiti, which handles TypeScript files correctly.

## Verification

After applying this fix locally, all memex tools appear in the pi tool registry and `memex_recall` works as expected.