### PR TITLE
feat(doctor): add --json flag for machine-readable output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -255,7 +255,8 @@ program
   .description("Check memex health and configuration")
   .option("--check-collisions", "Check for slug collisions in basename mode")
   .option("--verbose", "Show detailed output for warnings")
-  .action(async (opts: { checkCollisions?: boolean; verbose?: boolean }) => {
+  .option("--json", "Output results as JSON for programmatic use")
+  .action(async (opts: { checkCollisions?: boolean; verbose?: boolean; json?: boolean }) => {
     const home = await resolveMemexHome();
     const cardsDir = join(home, "cards");
     const archiveDir = join(home, "archive");
@@ -265,7 +266,7 @@ program
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     } else {
-      const result = await doctorRunAll(cardsDir, archiveDir, opts.verbose);
+      const result = await doctorRunAll(cardsDir, archiveDir, opts.verbose, opts.json);
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,6 +10,7 @@ export interface CheckResult {
   name: string;
   status: "ok" | "warn" | "error";
   message: string;
+  details?: string[];
 }
 
 interface CollisionGroup {
@@ -117,6 +118,7 @@ export async function checkOrphans(
       name: "Orphans",
       status: "warn",
       message,
+      details: orphans,
     };
   } catch (e) {
     return {
@@ -155,14 +157,15 @@ export async function checkBrokenLinks(
 
     let message = `${broken.length} link(s) to non-existent cards`;
     if (verbose) {
-      const details = broken.map((b) => `  ${b.from} → ${b.to}`).join("\n");
-      message += "\n" + details;
+      const detailLines = broken.map((b) => `  ${b.from} → ${b.to}`).join("\n");
+      message += "\n" + detailLines;
     }
 
     return {
       name: "Broken links",
       status: "warn",
       message,
+      details: broken.map((b) => `${b.from} → ${b.to}`),
     };
   } catch (e) {
     return {
@@ -181,7 +184,8 @@ function formatCheckResult(r: CheckResult): string {
 export async function doctorRunAll(
   cardsDir: string,
   archiveDir: string,
-  verbose?: boolean
+  verbose?: boolean,
+  json?: boolean
 ): Promise<DoctorResult> {
   const results = await Promise.all([
     checkCollisions(cardsDir, archiveDir),
@@ -189,8 +193,18 @@ export async function doctorRunAll(
     checkBrokenLinks(cardsDir, archiveDir, verbose),
   ]);
 
-  const output = results.map(formatCheckResult).join("\n");
   const hasError = results.some((r) => r.status === "error");
+
+  if (json) {
+    const jsonOutput = results.map((r) => ({
+      name: r.name,
+      status: r.status,
+      ...(r.details ? { details: r.details } : {}),
+    }));
+    return { exitCode: hasError ? 1 : 0, output: JSON.stringify(jsonOutput, null, 2) };
+  }
+
+  const output = results.map(formatCheckResult).join("\n");
   return { exitCode: hasError ? 1 : 0, output };
 }
 

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -230,4 +230,34 @@ describe("doctorRunAll", () => {
     expect(result.exitCode).toBe(1);
     expect(result.output).toContain("✗ Slug collisions");
   });
+
+  it("outputs valid JSON with --json flag", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "no links");
+    await writeFile(join(cardsDir, "c.md"), "links to [[missing]]");
+
+    const result = await doctorRunAll(cardsDir, archiveDir, false, true);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output!);
+    expect(parsed).toHaveLength(3);
+    expect(parsed[0]).toHaveProperty("name", "Slug collisions");
+    expect(parsed[0]).toHaveProperty("status", "ok");
+    expect(parsed[1]).toHaveProperty("name", "Orphans");
+    expect(parsed[1]).toHaveProperty("status", "warn");
+    expect(parsed[1].details).toContain("a");
+    expect(parsed[2]).toHaveProperty("name", "Broken links");
+    expect(parsed[2]).toHaveProperty("status", "warn");
+    expect(parsed[2].details).toContain("c → missing");
+  });
+
+  it("omits details in JSON when check is ok", async () => {
+    await writeFile(join(cardsDir, "a.md"), "links to [[b]]");
+    await writeFile(join(cardsDir, "b.md"), "links to [[a]]");
+
+    const result = await doctorRunAll(cardsDir, archiveDir, false, true);
+    const parsed = JSON.parse(result.output!);
+    expect(parsed[0]).not.toHaveProperty("details");
+    expect(parsed[1]).not.toHaveProperty("details");
+    expect(parsed[2]).not.toHaveProperty("details");
+  });
 });


### PR DESCRIPTION
## Summary

Adds `--json` option to `memex doctor` for structured machine-readable output.

## Motivation

While `doctor` and `doctor --verbose` are great for interactive use, CI pipelines and scripts need structured data. `--json` outputs a JSON array where each check includes `name`, `status`, and an optional `details` array.

## Example

```bash
memex doctor --json
```

```json
[
  { "name": "Slug collisions", "status": "ok" },
  { "name": "Orphans", "status": "warn", "details": ["card-a", "card-b"] },
  { "name": "Broken links", "status": "warn", "details": ["card-a → missing"] }
]
```

- `details` is omitted when status is `ok` (no noise)
- Broken links use `from → to` format
- Exit code behavior unchanged

## Changes

- `src/commands/doctor.ts`: Added optional `details` field to `CheckResult`, added `json` param to `doctorRunAll`
- `src/cli.ts`: Added `--json` CLI option
- `tests/commands/doctor.test.ts`: 2 new tests covering JSON output and details omission

## Testing

All 249 tests pass (`npx vitest run tests/commands/ tests/lib/`). Manually verified with a real 201-card wiki.