### PR TITLE
fix(doctor): pass --json flag to --check-collisions path

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -262,7 +262,7 @@ program
     const archiveDir = join(home, "archive");
 
     if (opts.checkCollisions) {
-      const result = await doctorCommand(cardsDir, archiveDir);
+      const result = await doctorCommand(cardsDir, archiveDir, opts.json);
       if (result.output) process.stdout.write(result.output + "\n");
       exit(result.exitCode);
     } else {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -211,7 +211,8 @@ export async function doctorRunAll(
 /** Legacy entry point for backward compat (collision check only) — preserves original output format */
 export async function doctorCommand(
   cardsDir: string,
-  archiveDir: string
+  archiveDir: string,
+  json?: boolean
 ): Promise<DoctorResult> {
   try {
     const basenameStore = new CardStore(cardsDir, archiveDir, false);
@@ -239,6 +240,12 @@ export async function doctorCommand(
     }
 
     if (collisions.length === 0) {
+      if (json) {
+        return {
+          exitCode: 0,
+          output: JSON.stringify([{ name: "Slug collisions", status: "ok" }], null, 2),
+        };
+      }
       return {
         exitCode: 0,
         output: "No slug collisions found. Safe to enable nestedSlugs.",
@@ -256,6 +263,17 @@ export async function doctorCommand(
     }
     lines.push("Resolve these collisions before enabling nestedSlugs.");
 
+    if (json) {
+      const details = collisions.map((c) => ({
+        slug: c.slug,
+        paths: c.paths,
+        fullPaths: c.fullPaths,
+      }));
+      return {
+        exitCode: 1,
+        output: JSON.stringify([{ name: "Slug collisions", status: "error", details }], null, 2),
+      };
+    }
     return { exitCode: 1, output: lines.join("\n") };
   } catch (e) {
     return {

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -74,6 +74,30 @@ describe("doctorCommand (legacy collision check)", () => {
     expect(result.output).toContain("would become: card");
     expect(result.output).toContain("would become: nested/deep/card");
   });
+
+  it("outputs JSON when --json flag is passed (no collisions)", async () => {
+    await writeFile(join(cardsDir, "foo.md"), "foo content");
+
+    const result = await doctorCommand(cardsDir, archiveDir, true);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.output!);
+    expect(parsed).toEqual([{ name: "Slug collisions", status: "ok" }]);
+  });
+
+  it("outputs JSON when --json flag is passed (with collisions)", async () => {
+    await mkdir(join(cardsDir, "sub"), { recursive: true });
+    await writeFile(join(cardsDir, "foo.md"), "foo root");
+    await writeFile(join(cardsDir, "sub", "foo.md"), "foo sub");
+
+    const result = await doctorCommand(cardsDir, archiveDir, true);
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.output!);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].name).toBe("Slug collisions");
+    expect(parsed[0].status).toBe("error");
+    expect(parsed[0].details).toBeDefined();
+    expect(parsed[0].details[0].slug).toBe("foo");
+  });
 });
 
 describe("checkOrphans", () => {


### PR DESCRIPTION
## Summary

Fixes #79 — when `--json` and `--check-collisions` were used together, the `--json` flag was silently ignored.

## Problem

The `--check-collisions` branch in cli.ts called `doctorCommand()` without forwarding the `json` option, so users got human-readable text regardless of the `--json` flag.

## Changes

- **`src/commands/doctor.ts`**: Added optional `json` parameter to `doctorCommand()`. When set, returns structured JSON matching `doctorRunAll`'s JSON format.
- **`src/cli.ts`**: Pass `opts.json` to `doctorCommand()` in the `--check-collisions` branch.
- **`tests/commands/doctor.test.ts`**: Added 2 tests covering JSON output for both collision and no-collision cases.

## Note on dist/

Not included in this PR to keep the diff clean (upstream's committed dist/ is already stale from #71/#72/#74/#76/#77). Happy to rebuild if preferred.

## Testing

```
npx vitest run tests/commands/doctor.test.ts
# 19 tests pass (including 2 new)
```