### PR TITLE
fix(sync): ensure cards/ directory exists before `git add` during init

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -154,6 +154,11 @@ export class GitAdapter implements SyncAdapter {
       }
     }
 
+    // Ensure cards/ exists. `git add cards` below would otherwise fail with
+    // "pathspec 'cards' did not match any files" on a fresh install where no
+    // card has ever been written, aborting the whole init.
+    await mkdir(join(this.home, "cards"), { recursive: true });
+
     // Init git repo if not already
     try {
       await execFile("git", ["-C", this.home, "rev-parse", "--git-dir"]);

--- a/tests/lib/sync.test.ts
+++ b/tests/lib/sync.test.ts
@@ -339,6 +339,39 @@ describe("GitAdapter", () => {
     }
   }, 15000);
 
+  it("init succeeds when cards/ directory does not exist (fresh install)", async () => {
+    // Simulate a fresh install: blow away the cards/ dir created in beforeEach.
+    // The remote is pre-seeded to mirror the common case of syncing a new
+    // device to an existing memex-cards repo.
+    await rm(join(home, "cards"), { recursive: true });
+
+    const bare = await mkdtemp(join(tmpdir(), "memex-bare-"));
+    await execFile("git", ["init", "--bare", bare]);
+    const seed = await mkdtemp(join(tmpdir(), "memex-seed-"));
+    await execFile("git", ["init", seed]);
+    await execFile("git", ["-C", seed, "checkout", "-b", "main"]);
+    await mkdir(join(seed, "cards"), { recursive: true });
+    await writeFile(
+      join(seed, "cards", "seed.md"),
+      "---\ntitle: Seed\ncreated: 2026-03-20\n---\nseed",
+      "utf-8"
+    );
+    await execFile("git", ["-C", seed, "add", "."]);
+    await execFile("git", ["-C", seed, "commit", "-m", "seed"]);
+    await execFile("git", ["-C", seed, "remote", "add", "origin", bare]);
+    await execFile("git", ["-C", seed, "push", "-u", "origin", "main"]);
+    await execFile("git", ["-C", bare, "symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    const adapter = new GitAdapter(home);
+    await adapter.init(bare);
+
+    const config = await readSyncConfig(home);
+    expect(config.remote).toBe(bare);
+
+    await rm(bare, { recursive: true });
+    await rm(seed, { recursive: true });
+  }, 20000);
+
   it("init accepts https:// URL (validation only)", async () => {
     const adapter = new GitAdapter(home);
     try {


### PR DESCRIPTION
## Summary

- Fixes #81 — `memex sync --init` no longer aborts on a fresh install where `~/.memex/cards/` has not been created yet.
- One-line fix: `mkdir -p cards/` at the start of `GitAdapter.init()`, before any `git` invocation that touches the path.
- Adds a regression test that simulates the real-world scenario: a fresh device syncing to an existing `memex-cards` remote.

## Why

On a fresh install, no card has been written yet, so `~/.memex/cards/` does not exist. `init()` then runs:

```ts
await execFile("git", ["-C", this.home, "add", "cards"]);
```

…which fails with `fatal: pathspec 'cards' did not match any files`, aborting the whole init and leaving the repo half-initialized (`.git`, `.gitignore`, and `origin` set, but no commit, no branch normalization, no push). The user has to manually `mkdir` and retry — and even then, the half-initialized state can cause downstream confusion.

`archive/` already has special handling (the `git add archive` call is wrapped in try/catch because the directory may not exist). `cards/` deserves the same treatment, but since it is conceptually required by memex anyway, just ensuring the directory exists is cleaner than swallowing errors.

## Test plan

- [x] New test `init succeeds when cards/ directory does not exist (fresh install)` passes
- [x] All 24 existing GitAdapter tests still pass
- [x] Full `npm test` suite passes (493 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)