### PR TITLE
feat(serve): add `--local` flag to force local UI when sync is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ memex serve
 
 Opens a visual timeline of all your cards at `localhost:3939`. Includes a **graph view** to explore bidirectional links.
 
-If you've set up sync, `memex serve` opens [memra.vercel.app](https://memra.vercel.app) — a web UI with Timeline, Graph view, and Share card.
+If you've set up sync, `memex serve` opens [memra.vercel.app](https://memra.vercel.app) — a web UI with Timeline, Graph view, and Share card. Pass `--local` to force the local UI instead (useful offline, or when you'd rather not send queries to a third-party web app):
+
+```bash
+memex serve --local
+```
 
 ![Graph View](docs/images/graph-view.png)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,8 +146,9 @@ program
   .command("serve")
   .description("Start web UI for browsing cards")
   .option("-p, --port <n>", "Port number", "3939")
-  .action(async (opts: { port: string }) => {
-    await serveCommand(parseInt(opts.port));
+  .option("--local", "Force local UI even when sync is configured (skip memra.vercel.app redirect)")
+  .action(async (opts: { port: string; local?: boolean }) => {
+    await serveCommand(parseInt(opts.port), { local: opts.local });
   });
 
 program

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -54,12 +54,15 @@ function injectBanner(html: string): string {
   return html.replace("<body>", "<body>" + banner);
 }
 
-export async function serveCommand(port: number): Promise<Server | null> {
+export async function serveCommand(
+  port: number,
+  opts: { local?: boolean } = {}
+): Promise<Server | null> {
   const home = await resolveMemexHome();
 
-  // Check if synced to GitHub → redirect to online
+  // Check if synced to GitHub → redirect to online (unless --local was passed).
   const syncConfig = await readSyncConfig(home);
-  if (syncConfig.remote) {
+  if (syncConfig.remote && !opts.local) {
     console.log(`Cards synced to ${syncConfig.remote}`);
     console.log(`Opening ${MEMRA_URL}...`);
     if (!process.env.MEMEX_NO_OPEN) {
@@ -71,7 +74,10 @@ export async function serveCommand(port: number): Promise<Server | null> {
     return null;
   }
 
-  // No sync — serve locally with banner
+  // Local mode (either no sync configured, or --local was passed).
+  // Suppress the "set up sync" banner when sync is already configured —
+  // there is nothing to advertise.
+  const showBanner = !syncConfig.remote;
   const store = new CardStore(join(home, "cards"), join(home, "archive"));
 
   const server = createServer(async (req, res) => {
@@ -188,7 +194,7 @@ export async function serveCommand(port: number): Promise<Server | null> {
       }
 
       if (url.pathname === "/" || url.pathname === "/index.html") {
-        const html = await getHTML(true);
+        const html = await getHTML(showBanner);
         res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
         res.end(html);
         return;
@@ -220,7 +226,9 @@ export async function serveCommand(port: number): Promise<Server | null> {
       server.listen(currentPort, '127.0.0.1', () => {
         const url = `http://localhost:${currentPort}`;
         console.log(`memex is running at ${url}`);
-        console.log("💡 Tip: Run 'memex sync --init' to sync and access your cards online");
+        if (showBanner) {
+          console.log("💡 Tip: Run 'memex sync --init' to sync and access your cards online");
+        }
         if (!process.env.MEMEX_NO_OPEN) {
           const bin = process.platform === "darwin" ? "open"
             : process.platform === "win32" ? "start"

--- a/tests/commands/serve.test.ts
+++ b/tests/commands/serve.test.ts
@@ -172,3 +172,61 @@ describe("serve API", () => {
     expect(res.body).toContain("Test Card");
   });
 });
+
+describe("serve --local flag", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-serve-local-test-"));
+    await mkdir(join(tmpDir, "cards"), { recursive: true });
+    await writeFile(
+      join(tmpDir, "cards", "card.md"),
+      "---\ntitle: Card\ncreated: 2025-01-15\n---\nbody"
+    );
+    // Simulate a configured sync remote — without --local, serve would redirect.
+    await writeFile(
+      join(tmpDir, ".sync.json"),
+      JSON.stringify({ remote: "git@github.com:user/memex-cards.git", adapter: "git", auto: false })
+    );
+
+    process.env.MEMEX_HOME = tmpDir;
+    process.env.MEMEX_NO_OPEN = "1";
+  });
+
+  afterAll(async () => {
+    delete process.env.MEMEX_HOME;
+    delete process.env.MEMEX_NO_OPEN;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null (redirects) when sync configured and --local not passed", async () => {
+    const result = await serveCommand(0);
+    expect(result).toBeNull();
+  });
+
+  it("starts local server when --local passed even with sync configured", async () => {
+    const port = 10000 + Math.floor(Math.random() * 50000);
+    const server = await serveCommand(port, { local: true });
+    try {
+      expect(server).not.toBeNull();
+      const res = await get(`http://localhost:${port}/api/cards`);
+      expect(res.status).toBe(200);
+      const cards = JSON.parse(res.body);
+      expect(cards).toHaveLength(1);
+      expect(cards[0].slug).toBe("card");
+    } finally {
+      server?.close();
+    }
+  });
+
+  it("suppresses sync banner in --local mode when sync is configured", async () => {
+    const port = 10000 + Math.floor(Math.random() * 50000);
+    const server = await serveCommand(port, { local: true });
+    try {
+      const res = await get(`http://localhost:${port}/`);
+      expect(res.body).not.toContain("sync-banner");
+    } finally {
+      server?.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #84 — `memex serve --local` now starts the local `localhost:3939` UI even when sync is configured, instead of unconditionally redirecting to `memra.vercel.app`.
- Suppresses the "set up sync" banner (both the HTML overlay and the stdout tip line) when sync is already configured — there is nothing to advertise.
- README updated.

## Why

See #84 for full context. tl;dr: there are several legitimate reasons to want the local UI (offline, privacy / trust, developing memex itself, restricted networks where memra.vercel.app is blocked), and prior to this PR there was no flag to express that — the only workaround was renaming `~/.memex/.sync.json`.

## Behavior

| Command                           | Sync configured? | Result                                      |
|-----------------------------------|:----------------:|---------------------------------------------|
| `memex serve`                     | no               | local UI at `localhost:3939` + sync banner  |
| `memex serve`                     | yes              | redirect to memra.vercel.app *(unchanged)*  |
| `memex serve --local`             | no               | local UI at `localhost:3939` + sync banner  |
| `memex serve --local`             | yes              | local UI at `localhost:3939`, no banner     |

## Implementation notes

- `serveCommand(port, opts?)` — `opts` defaults to `{}`, so existing callers (and the existing test suite) keep working unchanged.
- The redirect condition flips from `if (syncConfig.remote)` to `if (syncConfig.remote && !opts.local)`.
- A single `showBanner = !syncConfig.remote` value drives both the HTML banner injection and the stdout tip line, so the two stay in sync.

## Test plan

- [x] New `describe("serve --local flag")` block covers: default-redirect path, `--local` starts local server, `--local` suppresses banner when sync configured.
- [x] All 16 existing `serve API` tests still pass.
- [x] Full `npm test` passes (495 tests).

## Out of scope

The non-English README sections currently do not have a "Browse your memory" subsection at all (only English does). Per discussion, this PR only updates the English section to mention `--local`. Translating the whole subsection into 中文 / 日本語 / 한국어 / Español is left for a separate i18n pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)