### PR TITLE
🔧 fix: sync plugin.json version with package.json (0.1.31)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "memex",
   "description": "Zettelkasten-based agent memory system with bidirectional links",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "license": "MIT",
   "keywords": [
     "memory",


### PR DESCRIPTION
## Problem

CI tests are failing due to version inconsistency between:
- `package.json`: 0.1.31
- `.claude-plugin/plugin.json`: 0.1.30

Test failure: `tests/integration/hooks-skills-consistency.test.ts`

## Solution

Updated `.claude-plugin/plugin.json` version from 0.1.30 to 0.1.31 to match package.json.

## Impact

- ✅ Fixes CI test failure
- ✅ Maintains version consistency across all config files
- ✅ No breaking changes
- ✅ Safe to auto-merge