### PR TITLE
feat(links): add --json flag for machine-readable output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -108,10 +108,11 @@ program
   .description("Show link graph stats or specific card links")
   .option("--filter <type>", "Filter cards: orphan or hub")
   .option("--stats", "Show summary statistics instead of card list")
-  .action(async (slug?: string, cmdOpts?: { filter?: string; stats?: boolean }) => {
+  .option("--json", "Output results as JSON for programmatic use")
+  .action(async (slug?: string, cmdOpts?: { filter?: string; stats?: boolean; json?: boolean }) => {
     const store = await getStore();
     const filter = cmdOpts?.filter as "orphan" | "hub" | undefined;
-    const result = await linksCommand(store, slug, { filter, stats: cmdOpts?.stats });
+    const result = await linksCommand(store, slug, { filter, stats: cmdOpts?.stats, json: cmdOpts?.json });
     if (result.output) process.stdout.write(result.output + "\n");
     exit(result.exitCode);
   });

--- a/src/commands/links.ts
+++ b/src/commands/links.ts
@@ -12,6 +12,7 @@ interface LinksResult {
 export interface LinksOptions {
   filter?: "orphan" | "hub";
   stats?: boolean;
+  json?: boolean;
 }
 
 export async function linksCommand(store: CardStore, slug: string | undefined, opts?: LinksOptions): Promise<LinksResult> {
@@ -41,6 +42,9 @@ export async function linksCommand(store: CardStore, slug: string | undefined, o
   if (slug) {
     const outbound = outboundMap.get(slug) || [];
     const inbound = inboundMap.get(slug) || [];
+    if (opts?.json) {
+      return { output: JSON.stringify({ slug, outbound, inbound }, null, 2), exitCode: 0 };
+    }
     return { output: formatCardLinks(slug, outbound, inbound), exitCode: 0 };
   }
 
@@ -55,6 +59,28 @@ export async function linksCommand(store: CardStore, slug: string | undefined, o
     stats = stats.filter((s) => s.inbound === 0);
   } else if (filter === "hub") {
     stats = stats.filter((s) => s.inbound >= HUB_THRESHOLD);
+  }
+
+  if (opts?.json) {
+    if (opts?.stats) {
+      const orphans = stats.filter((s) => s.inbound === 0).length;
+      const hubs = stats.filter((s) => s.inbound >= HUB_THRESHOLD).length;
+      const totalOut = stats.reduce((sum, s) => sum + s.outbound, 0);
+      const totalIn = stats.reduce((sum, s) => sum + s.inbound, 0);
+      return {
+        output: JSON.stringify({
+          totalCards: cards.length,
+          showing: filter || "all",
+          count: stats.length,
+          orphans,
+          hubs,
+          avgOutbound: stats.length > 0 ? +(totalOut / stats.length).toFixed(1) : 0,
+          avgInbound: stats.length > 0 ? +(totalIn / stats.length).toFixed(1) : 0,
+        }, null, 2),
+        exitCode: 0,
+      };
+    }
+    return { output: JSON.stringify(stats, null, 2), exitCode: 0 };
   }
 
   if (opts?.stats) {

--- a/tests/commands/links.test.ts
+++ b/tests/commands/links.test.ts
@@ -74,4 +74,53 @@ describe("linksCommand", () => {
     expect(result.output).toContain("Showing: orphan");
     expect(result.output).toContain("Total cards: 4");
   });
+
+  it("outputs JSON array for global links", async () => {
+    const result = await linksCommand(store, undefined, { json: true });
+    const data = JSON.parse(result.output);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data).toHaveLength(3);
+    const a = data.find((d: any) => d.slug === "a");
+    expect(a).toBeDefined();
+    expect(a.outbound).toBe(2);
+    expect(a.inbound).toBe(1);
+  });
+
+  it("outputs JSON for specific card", async () => {
+    const result = await linksCommand(store, "a", { json: true });
+    const data = JSON.parse(result.output);
+    expect(data.slug).toBe("a");
+    expect(data.outbound).toEqual(["b", "c"]);
+    expect(data.inbound).toEqual(["b"]);
+  });
+
+  it("outputs JSON stats summary", async () => {
+    const result = await linksCommand(store, undefined, { json: true, stats: true });
+    const data = JSON.parse(result.output);
+    expect(data.totalCards).toBe(3);
+    expect(data.showing).toBe("all");
+    expect(data.count).toBe(3);
+    expect(data.orphans).toBe(0);
+    expect(data.hubs).toBe(0);
+    expect(typeof data.avgOutbound).toBe("number");
+    expect(typeof data.avgInbound).toBe("number");
+  });
+
+  it("outputs JSON with filter", async () => {
+    await writeFile(join(tmpDir, "cards", "orphan.md"), "---\ntitle: Orphan\n---\nNo one links here.");
+    const result = await linksCommand(store, undefined, { json: true, filter: "orphan" });
+    const data = JSON.parse(result.output);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.every((d: any) => d.inbound === 0)).toBe(true);
+    expect(data.some((d: any) => d.slug === "orphan")).toBe(true);
+  });
+
+  it("outputs JSON stats with filter", async () => {
+    await writeFile(join(tmpDir, "cards", "orphan.md"), "---\ntitle: Orphan\n---\nNo one links here.");
+    const result = await linksCommand(store, undefined, { json: true, stats: true, filter: "orphan" });
+    const data = JSON.parse(result.output);
+    expect(data.showing).toBe("orphan");
+    expect(data.count).toBe(1);
+    expect(data.totalCards).toBe(4);
+  });
 });


### PR DESCRIPTION
Closes #91

## What

Add `--json` flag to `memex links` command for machine-readable output, bringing it to parity with `doctor --json` (#78).

## Changes

- **`src/commands/links.ts`**: Add `json` option to `LinksOptions`, output JSON in all modes (global, single-card, stats, with filters)
- **`src/cli.ts`**: Wire `--json` option to links command
- **`tests/commands/links.test.ts`**: Add 5 tests covering all JSON output modes

## Output Examples

```bash
# Global mode — array of stats objects
memex links --json
# [{"slug":"acp","outbound":7,"inbound":5}, ...]

# Single card — full link lists
memex links acp --json
# {"slug":"acp","outbound":["acpx-exec-vs-acp-runtime",...],"inbound":[...]}

# Stats summary
memex links --json --stats
# {"totalCards":208,"showing":"all","orphans":52,"hubs":5,...}

# With filter
memex links --json --filter orphan
# [{"slug":"orphan-card","outbound":1,"inbound":0}, ...]
```

## Tests

All 11 links tests pass (6 existing + 5 new).