### PR TITLE
fix: make prepare script cross-platform for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "GEMINI.md"
   ],
   "scripts": {
-    "prepare": "[ -d .git ] && cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit || true",
+    "prepare": "node -e \"const fs=require('fs'),p=require('path');if(fs.existsSync('.git')){fs.mkdirSync(p.join('.git','hooks'),{recursive:true});fs.copyFileSync(p.join('scripts','pre-commit'),p.join('.git','hooks','pre-commit'))}\" || true",
     "build": "node scripts/bundle.mjs",
     "postbuild": "node scripts/postbuild.mjs",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "GEMINI.md"
   ],
   "scripts": {
-    "prepare": "node -e \"const fs=require('fs'),p=require('path');if(fs.existsSync('.git')){fs.mkdirSync(p.join('.git','hooks'),{recursive:true});fs.copyFileSync(p.join('scripts','pre-commit'),p.join('.git','hooks','pre-commit'))}\" || true",
+    "prepare": "node -e \"const fs=require('fs'),p=require('path');if(fs.existsSync('.git')){fs.mkdirSync(p.join('.git','hooks'),{recursive:true});fs.copyFileSync(p.join('scripts','pre-commit'),p.join('.git','hooks','pre-commit'));if(process.platform!=='win32')fs.chmodSync(p.join('.git','hooks','pre-commit'),0o755)}\" || true",
     "build": "node scripts/bundle.mjs",
     "postbuild": "node scripts/postbuild.mjs",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
## Summary
- The prepare hook used Unix-only shell syntax which fails on Windows cmd.exe during npm install
- Replaced with a cross-platform Node.js one-liner

## Test plan
- [ ] npm install on Windows succeeds
- [ ] npm install on macOS/Linux still works
- [ ] .git/hooks/pre-commit is copied correctly