### PR TITLE
fix(parser): handle pipe aliases and ignore code blocks in extractLinks

### DIFF
--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -37,11 +37,20 @@ export function stringifyFrontmatter(
 }
 
 export function extractLinks(body: string): string[] {
+  // Strip fenced code blocks and inline code to avoid false positives
+  const stripped = body
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`\n]+`/g, "");
+
   const re = /\[\[([^\]]+)\]\]/g;
   const links = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = re.exec(body)) !== null) {
-    links.add(match[1]);
+  while ((match = re.exec(stripped)) !== null) {
+    // Support Obsidian-style pipe aliases: [[target|display text]] → target
+    const target = match[1].split("|")[0].trim();
+    if (target) {
+      links.add(target);
+    }
   }
   return [...links];
 }

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -58,6 +58,30 @@ describe("extractLinks", () => {
     expect(links).toEqual(["foo"]);
   });
 
+  it("strips pipe aliases from wikilinks", () => {
+    const content = "See [[dreaming|OpenClaw dreaming metaphor]] and [[target|display text]].";
+    const links = extractLinks(content);
+    expect(links).toEqual(["dreaming", "target"]);
+  });
+
+  it("ignores wikilinks inside fenced code blocks", () => {
+    const content = "Real [[link-a]].\n```\n[[not-a-link]]\n```\nAlso [[link-b]].";
+    const links = extractLinks(content);
+    expect(links).toEqual(["link-a", "link-b"]);
+  });
+
+  it("ignores wikilinks inside inline code", () => {
+    const content = "Use `[[not-a-link]]` to reference, but [[real-link]] works.";
+    const links = extractLinks(content);
+    expect(links).toEqual(["real-link"]);
+  });
+
+  it("handles pipe alias with no display text gracefully", () => {
+    const content = "See [[target|]].";
+    const links = extractLinks(content);
+    expect(links).toEqual(["target"]);
+  });
+
   it("extracts links only from body, not frontmatter", () => {
     const content = `---
 title: "About [[not-a-link]]"


### PR DESCRIPTION
## Problem (fixes #101)

`extractLinks()` has two issues causing false broken links:

### 1. Pipe aliases not stripped
Obsidian-style `[[target|display text]]` is standard wikilink syntax, but `extractLinks` captures the full inner text including the pipe, creating false broken link targets like `dreaming|OpenClaw dreaming metaphor`.

### 2. Code blocks not stripped  
Wikilinks inside inline code or fenced code blocks are parsed as real links, creating false positives from documentation examples.

## Fix

In `extractLinks()`:
1. Strip fenced code blocks (```` ``` `...` ``` ````) and inline code (`` `...` ``) before regex matching
2. Extract only the part before `|` in wikilinks: `match[1].split("|")[0].trim()`
3. Skip empty targets (e.g. `[[|]]`)

## Tests

4 new tests added:
- Pipe alias extraction (`[[dreaming|display text]]` → `dreaming`)
- Fenced code block exclusion
- Inline code exclusion
- Empty display text edge case (`[[target|]]` → `target`)

All 77 tests pass across parser, doctor, links, and backlinks test files.

## Impact

In a 210+ card wiki, these two issues accounted for ~6 of 28 remaining broken links after the `extraLinkDirs` fix (#99).