### PR TITLE
feat: add A-MEM-inspired experimental agentic memory skill

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,374 @@
+# Memex Architecture Reference
+
+> Comprehensive technical documentation for contributors and AI coding agents.
+> For quick-start instructions, see the root README.md.
+
+## 1. Project Overview
+
+**Memex** (`@touchskyer/memex`) is a persistent Zettelkasten memory system for AI coding agents. It stores atomic knowledge cards as markdown files in `~/.memex/cards/`, using `[[wikilinks]]` for bidirectional linking. No vector database, no embeddings required (optional).
+
+**Core philosophy**: Recall → Work → Retro. Every session starts by recalling prior knowledge, ends by saving new insights.
+
+**Repository**: https://github.com/iamtouchskyer/memex
+**License**: MIT
+
+## 2. Architecture Layers
+
+```
+┌─────────────────────────────────────────────┐
+│              Client Layer                   │
+│  Claude Code │ VS Code │ Cursor │ Pi │ MCP │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│           MCP Server (src/mcp/)             │
+│  10 tools: recall, retro, organize,         │
+│  search, read, write, links, archive,       │
+│  pull, push                                 │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│           Command Layer (src/commands/)      │
+│  search, read, write, links, backlinks,     │
+│  archive, organize, serve, sync, import,    │
+│  doctor, migrate                            │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│           Library Layer (src/lib/)           │
+│  CardStore, Parser, Formatter, HookRegistry,│
+│  GitAdapter, EmbeddingProvider, Config       │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│           Storage (~/.memex/)               │
+│  cards/  archive/  .sync.json  .memexrc     │
+└─────────────────────────────────────────────┘
+```
+
+## 3. Source Code Map
+
+```
+src/
+├── cli.ts                    # CLI entry point (commander)
+├── mcp/
+│   ├── server.ts             # MCP server factory, client-aware source tagging
+│   └── operations.ts         # High-level MCP tools: recall, retro, organize, pull, push
+├── commands/
+│   ├── search.ts             # Keyword + semantic search, manifest pre-filter
+│   ├── read.ts               # Read card by slug
+│   ├── write.ts              # Write card (validates frontmatter, updates modified date)
+│   ├── links.ts              # Link graph stats (single card or global)
+│   ├── backlinks.ts          # Find cards linking TO a slug
+│   ├── archive.ts            # Move card to archive/
+│   ├── organize.ts           # Network analysis: orphans, hubs, conflicts, pairs
+│   ├── serve.ts              # Web UI server (serve-ui.html)
+│   ├── sync.ts               # CLI sync orchestrator (init, pull, push, auto toggle)
+│   ├── import.ts             # Import dispatcher
+│   ├── doctor.ts             # Health checks (slug collision detection)
+│   └── migrate.ts            # Config migration (enable nestedSlugs)
+├── lib/
+│   ├── store.ts              # CardStore: scan, resolve, read, write, archive (atomic writes)
+│   ├── parser.ts             # Frontmatter parse/stringify, wikilink extraction
+│   ├── formatter.ts          # Output formatters (card list, search result, link stats)
+│   ├── hooks.ts              # HookRegistry: pre/post lifecycle hooks
+│   ├── sync.ts               # GitAdapter, SyncConfig, autoSync/autoFetch
+│   ├── config.ts             # .memexrc reader
+│   ├── embeddings.ts         # OpenAI/Azure/Local/Ollama providers, cache, cosine similarity
+│   └── utils.ts              # semverSort utility
+├── importers/
+│   ├── index.ts              # Importer registry
+│   └── openclaw.ts           # OpenClaw importer
+skills/                       # Claude Code skills (bundled in plugin)
+├── memex-recall/SKILL.md
+├── memex-retro/SKILL.md
+├── memex-organize/SKILL.md
+├── memex-sync/SKILL.md
+├── memex-best-practices/SKILL.md
+├── memex-agentic-memory/SKILL.md  # Experimental (requires agenticMemory flag)
+└── agent-prompts-warmup/SKILL.md  # FRE audit and agent instruction sync
+hooks/
+└── hooks.json                # Claude Code SessionStart hook
+.claude-plugin/
+├── plugin.json               # Plugin metadata
+└── marketplace.json          # Claude Code marketplace registration
+pi-extension/
+└── index.ts                  # Pi agent extension (8 tools, lifecycle hooks)
+vscode-extension/             # VS Code extension (bundles MCP server)
+tests/                        # Vitest test suite
+```
+
+## 4. Data Model
+
+### Card Format
+
+File: `~/.memex/cards/<slug>.md`
+
+```yaml
+---
+title: Short Noun Phrase (<=60 chars)
+created: 2025-01-15
+modified: 2025-01-16
+source: claude-code
+category: backend
+tags: [typescript, gotcha]
+status: conflict
+---
+
+Atomic insight in own words, with [[wikilinks]] to related cards.
+
+This connects to [[jwt-revocation]] because stateless tokens
+need server-side revocation via [[blacklist-pattern]].
+```
+
+**Required fields**: `title`, `created`, `source`
+**Auto-managed**: `modified` (updated on every write), `source` (injected by MCP server from clientInfo)
+
+### Slug Rules
+
+- **Format**: kebab-case, lowercase English, 3-60 chars
+- **Validation** (`store.ts:validateSlug`):
+  - No empty/whitespace-only slugs
+  - No reserved chars: `: * ? " < > |`
+  - No empty path segments, no `..` traversal
+  - Path-safe assertion: must resolve within `cardsDir`
+- **Special prefixes**: `adr-*`, `gotcha-*`, `pattern-*`, `tool-*`
+
+### Storage Layout
+
+```
+~/.memex/
+├── cards/              # Active cards (.md)
+├── archive/            # Archived cards
+├── .sync.json          # Sync config (remote, auto, lastSync)
+├── .memexrc            # User config (JSON)
+├── .last-organize      # Timestamp of last organize
+├── .memex/embeddings/  # Embedding cache (per-model JSON)
+└── .git/               # Git repo (if sync initialized)
+```
+
+## 5. MCP Tools (10 total)
+
+### High-Level (with hooks)
+
+| Tool | Purpose | Hooks |
+|------|---------|-------|
+| `memex_recall` | Load prior knowledge at task start. Returns index card or card list. | `pre:recall` (autoFetch) |
+| `memex_retro` | Save atomic insight at task end. Auto-injects source, date, syncs. | `pre:retro` (autoFetch), `post:retro` (autoSync) |
+| `memex_organize` | Analyze network: orphans, hubs, conflicts, contradiction pairs. | `pre:organize` (autoFetch), `post:organize` (autoSync) |
+| `memex_pull` | Pull remote changes. | `pre:pull`, `post:pull` |
+| `memex_push` | Push local changes. | `pre:push`, `post:push` |
+
+### Low-Level (no hooks)
+
+| Tool | Purpose |
+|------|---------|
+| `memex_search` | Full-text keyword search (AND logic) or list all cards |
+| `memex_read` | Read card by slug |
+| `memex_write` | Write/update card with full content |
+| `memex_links` | Link stats (per-card or global) |
+| `memex_archive` | Move card to archive |
+
+## 6. Hook System
+
+**Registry** (`src/lib/hooks.ts`): `Map<HookKey, HookFn[]>` where `HookKey = "${Phase}:${Operation}"`.
+
+- **Phase**: `pre` | `post`
+- **Operation**: `recall` | `retro` | `organize` | `show` | `pull` | `push` | `init`
+- **Behavior**: hooks fail silently (infrastructure, not business logic)
+
+**Default hooks** (registered in `server.ts`):
+
+```
+pre:recall   → autoFetch (pull latest)
+pre:retro    → autoFetch
+pre:organize → autoFetch
+post:retro   → autoSync (commit + push if auto=true)
+post:organize → autoSync
+```
+
+## 7. Sync System
+
+**Adapter**: `GitAdapter` (`src/lib/sync.ts`)
+
+- **Init**: Creates/reuses `memex-cards` GitHub repo via `gh` CLI, or accepts custom URL
+- **Pull**: `git fetch origin` → `git merge <remoteBranch> --no-edit`
+- **Push**: `git add cards archive` → `git commit` → `git push origin HEAD`
+- **Remote detection**: `origin/HEAD` → `origin/main` → `origin/master` → fallback `origin/main`
+- **Auto-sync**: Enabled with `memex sync on`. Runs after retro/organize.
+- **Offline tolerance**: autoFetch/autoSync silently fail when offline
+
+## 8. Search
+
+### Keyword Search (default)
+
+- AND logic: ALL tokens must match
+- Case-insensitive, searches title + body (frontmatter excluded)
+- Ranked by token frequency
+
+### Semantic Search (`--semantic`)
+
+- Providers: OpenAI (`text-embedding-3-small`), Azure OpenAI (`text-embedding-3-large` deployment), Local (`node-llama-cpp` + GGUF), Ollama (`nomic-embed-text`)
+- Hybrid scoring: `0.7 * semantic + 0.3 * keyword_normalized`
+- Embedding cache: `~/.memex/.memex/embeddings/<model>.json`, invalidated by SHA-256 content hash
+- Auto-detection: OpenAI API key -> Azure OpenAI endpoint + key -> node-llama-cpp -> error; Ollama is explicit-only
+
+### Manifest Filters
+
+`--category`, `--tag`, `--author/--source`, `--since`, `--before` (applied as pre-filter before search)
+
+## 9. Organize
+
+`organizeCommand` (`src/commands/organize.ts`) builds full link graph:
+
+1. **Link stats**: outbound/inbound counts per card
+2. **Orphan detection**: cards with 0 inbound (excluding `index`)
+3. **Hub detection**: cards with ≥10 inbound
+4. **Conflict cards**: frontmatter `status: conflict`
+5. **Contradiction pairs**: recently modified cards + their neighbors (max 20 pairs, 300-char excerpts)
+6. **Incremental**: uses `~/.memex/.last-organize` timestamp; `--since` overrides
+
+## 10. Platform Integrations
+
+### Claude Code Plugin
+
+- **SessionStart hook** (`hooks/hooks.json`): checks CLI install, runs sync, injects recall/retro reminders
+- **7 skills**: recall, retro, organize, sync, best-practices, agentic-memory (experimental), agent-prompts-warmup
+- **Install**: `/plugin install memex@memex`
+- **Marketplace**: `.claude-plugin/marketplace.json`
+
+### VS Code Extension
+
+- **Location**: `vscode-extension/`
+- Bundles `@touchskyer/memex` as dependency
+- Registers MCP server via `vscode.lm.registerMcpServerDefinitionProvider`
+- Node discovery: system PATH → common install paths → NVM (sorted by semver)
+
+### Pi Extension
+
+- **Location**: `pi-extension/index.ts`
+- Single file, zero npm dependencies
+- 8 tools (spawns `memex` CLI process)
+- Lifecycle hooks: `before_agent_start` (recall reminder), `agent_end` (retro reminder)
+- Slash commands: `/memex`, `/memex-serve`, `/memex-sync`
+
+## 11. Build & Test
+
+### Build
+
+```bash
+npm run build      # tsc → dist/
+npm run postbuild  # copies serve-ui.html, share-card assets, syncs AGENTS.md → agent instruction files
+```
+
+**TypeScript**: ES2022, Node16 module resolution, strict mode, declarations, source maps.
+
+### Dependencies
+
+| Dep | Purpose |
+|-----|---------|
+| `@modelcontextprotocol/sdk` | MCP server framework |
+| `commander` | CLI framework |
+| `gray-matter` | YAML frontmatter parsing |
+| `zod` | Schema validation (MCP tool inputs) |
+
+**Optional**: `node-llama-cpp` (local embeddings)
+
+### Test
+
+```bash
+npm test              # vitest run
+npm run test:watch    # vitest watch mode
+```
+
+**Coverage**: v8 provider, 70% statement threshold, `src/cli.ts` excluded.
+
+### Package Distribution
+
+- **npm**: `@touchskyer/memex` (includes `dist/`, `skills/`, `pi-extension/`)
+- **VS Code**: `touchskyer.memex-mcp` marketplace extension
+- **Claude Code**: plugin via marketplace (`memex@memex`)
+- **Binary**: `memex` (via `package.json` `bin` field → `dist/cli.js`)
+
+## 12. Configuration Reference
+
+### .memexrc (JSON)
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `nestedSlugs` | boolean | false | Path-preserving slugs |
+| `searchDirs` | string[] | — | Extra dirs for `--all` |
+| `embeddingProvider` | "openai"\|"azure"\|"local"\|"ollama" | auto-detect | |
+| `openaiApiKey` | string | env `OPENAI_API_KEY` | |
+| `openaiBaseUrl` | string | `https://api.openai.com` | |
+| `embeddingModel` | string | `text-embedding-3-small` | OpenAI model or Azure deployment | |
+| `azureOpenaiEndpoint` | string | env `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint, e.g. `/openai/v1/` |
+| `azureOpenaiApiKey` | string | env `AZURE_OPENAI_API_KEY` | Prefer env/key file |
+| `azureOpenaiApiKeyPath` | string | `~/.azure_api_key` | Local key file path |
+| `ollamaModel` | string | `nomic-embed-text` | |
+| `ollamaBaseUrl` | string | `http://localhost:11434` | |
+| `localModelPath` | string | HuggingFace URI | |
+| `experimental` | object | — | Experimental feature flags (see below) |
+
+#### Experimental Flags
+
+The `experimental` field is an optional object for gating features that are not yet stable.
+
+| Flag | Type | Default | Notes |
+|------|------|---------|-------|
+| `agenticMemory` | boolean | `false` | Enables the A-MEM-inspired agentic memory skill workflow. Only `true` activates; `false`, `null`, missing, or non-boolean values are treated as disabled. |
+
+Example `.memexrc` with experimental flags:
+
+```json
+{
+  "experimental": {
+    "agenticMemory": true
+  }
+}
+```
+
+When `agenticMemory` is enabled, agents may use the `memex-agentic-memory` skill for structured knowledge capture (observe → draft → enrich → retrieve → decide → preview → write → verify). When disabled, agents use the standard `memex-retro` workflow. See `skills/memex-agentic-memory/SKILL.md` for the full skill specification.
+
+### Environment Variables
+
+| Var | Purpose |
+|-----|---------|
+| `MEMEX_HOME` | Override home dir (default `~/.memex`) |
+| `OPENAI_API_KEY` | OpenAI embeddings |
+| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key |
+| `AZURE_OPENAI_API_KEY_FILE` | Azure OpenAI API key file path |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | Azure OpenAI embedding deployment override |
+| `OPENAI_BASE_URL` | Custom OpenAI endpoint |
+| `MEMEX_EMBEDDING_PROVIDER` | Force provider type |
+| `MEMEX_OLLAMA_MODEL` | Ollama model override |
+| `MEMEX_OLLAMA_BASE_URL` | Ollama endpoint override |
+
+## 13. Key Implementation Details
+
+### Atomic Writes
+
+`CardStore.writeCard()` writes to `<path>.tmp` then `rename()` — prevents corruption on crash.
+
+### Cache Invalidation
+
+- `CardStore.scanCache`: invalidated after every write/archive
+- `EmbeddingCache`: SHA-256 content hash per card, stale entries cleaned on `embedCards()`
+
+### Client Source Tagging
+
+MCP server intercepts `initialize` handshake, captures `clientInfo.name`, normalizes to kebab-case. Auto-injected into `source` frontmatter on writes via `memex_write` and `memex_retro`.
+
+### Path Safety
+
+- `assertSafePath()`: resolved path must be within `cardsDir` (or `archiveDir`)
+- `validateSlug()`: rejects traversal, reserved chars, empty segments
+- Windows normalization: `\` → `/` in slugs
+
+### Frontmatter Stringification
+
+Custom YAML generation (avoids `js-yaml` block scalars `>-`):
+- Special chars quoted with single quotes
+- Single quotes escaped: `'` → `''`
+- Newlines replaced with spaces

--- a/docs/superpowers/specs/2026-05-03-agentic-memory-skill-dev-spec.md
+++ b/docs/superpowers/specs/2026-05-03-agentic-memory-skill-dev-spec.md
@@ -1,0 +1,286 @@
+# Dev Spec: Experimental Agentic Memory Skill
+
+Status: Draft
+Date: 2026-05-03
+Related PRD: `docs/superpowers/specs/2026-05-03-agentic-memory-skill-prd.md`
+
+## Design Principle
+
+Do not build an A-MEM clone inside memex core. Build an A-MEM-inspired skill workflow that leverages the current agent plus existing memex tools.
+
+The core boundary remains:
+
+```text
+MCP tools / CLI -> commands -> lib -> filesystem
+```
+
+Agentic reasoning stays in the skill. Core memex remains responsible for configuration, parsing, path safety, atomic writes, search, and sync.
+
+## Proposed Architecture
+
+```text
+skills/memex-agentic-memory/SKILL.md
+  -> uses memex_search / memex_read / memex_write / memex_retro
+  -> performs agent reasoning for create (with links), update, skip
+  -> gated by .memexrc.experimental.agenticMemory
+
+src/lib/config.ts
+  -> parses experimental.agenticMemory
+  -> default false
+
+optional later, separate from agentic-memory v1:
+src/commands/search.ts / src/lib/embeddings.ts
+  -> enhanced retrieval text as an independent search improvement with its own tests
+```
+
+## Feature Flag
+
+Add `experimental` to the existing `MemexConfig` interface (which already has ~15 fields for embedding providers, search dirs, etc.):
+
+```typescript
+// Add to the existing MemexConfig interface in src/lib/config.ts
+experimental?: {
+  agenticMemory?: boolean;
+};
+```
+
+Add parsing in `readConfig()` alongside the existing field parsers:
+
+```typescript
+experimental: parseExperimental(parsed.experimental),
+```
+
+Parsing rules:
+
+- `experimental` must be an object (not null, string, number, or array).
+- `agenticMemory` is enabled only when the value is exactly `true`.
+- Missing, false, null, string, or number values are treated as disabled.
+- Existing config keys remain backward compatible.
+- The `readConfig` function already uses strict type checks per field; follow the same pattern.
+
+Example `.memexrc`:
+
+```json
+{
+  "experimental": {
+    "agenticMemory": true
+  }
+}
+```
+
+## Skill Guard
+
+The skill must start with a guard step:
+
+1. Locate memex home using the same precedence as core memex where possible: `MEMEX_HOME`, upward `.memexrc`, then `~/.memex`.
+2. Read `.memexrc`.
+3. Continue only if `experimental.agenticMemory === true`.
+4. If disabled, fall back to existing `memex-retro` behavior and do not perform agentic update workflow.
+
+A later PR may add a small CLI helper such as `memex config get experimental.agenticMemory`, but the first skill can self-gate through file inspection if needed.
+
+## Skill Workflow
+
+### Step 1: Input Triage
+
+Identify whether there is a memory-worthy insight. Skip if the content is temporary, obvious, or not reusable.
+
+### Step 2: Draft Atomic Card
+
+Produce one card per insight:
+
+- short title
+- kebab-case slug
+- one atomic body
+- explicit project/domain context when needed
+
+### Step 3: Metadata Draft
+
+Generate candidate metadata:
+
+- `context`: one sentence explaining domain and purpose
+- `keywords`: 3-8 salient terms
+- `tags`: broad categories useful for retrieval
+
+Important: metadata storage is experimental. Until frontmatter serialization is finalized, the skill must not rely on array round-tripping through `writeCommand`.
+
+### Step 4: Candidate Retrieval
+
+Run retrieval before writing:
+
+```text
+memex search "<topic query>" --semantic --compact --limit 8
+```
+
+If semantic search fails or is unavailable:
+
+```text
+memex search "<topic query>" --compact --limit 8
+```
+
+Read the top candidates that look relevant:
+
+```text
+memex read <slug>
+```
+
+Recommended limits:
+
+- max candidate searches: 3
+- max cards read: 10
+- max link hops: 2
+
+### Step 5: Decision
+
+Choose exactly one primary action per insight:
+
+| Action | When |
+|--------|------|
+| create | No existing card covers the insight |
+| create with links | No existing card covers the insight, but candidate cards are meaningfully related — create a new card and embed wikilinks with relationship explanations |
+| update | Existing card covers the same insight but lacks new detail (requires preview) |
+| skip | Insight is duplicate, too obvious, or not durable |
+
+Note: there is no "link-only" action in v1. Adding wikilinks to an existing card without other changes is an update and requires the update preview flow.
+
+Merge/archive is excluded from v1 unless the user explicitly asks.
+
+### Step 6: Preview
+
+Before writing, produce a preview:
+
+```text
+Planned memory changes:
+- create: <slug> (<title>)
+- update: <slug> because <reason>
+- links: [[a]], [[b]] because <relationship>
+- metadata: context/keywords/tags draft
+```
+
+For updates to existing cards, the agent must explain why updating is better than creating a new card.
+
+### Step 7: Write
+
+Use existing memex write paths. Preserve frontmatter on update.
+
+For a new card, required fields remain:
+
+```yaml
+---
+title: <title>
+created: <YYYY-MM-DD>
+source: <client or agent>
+category: <optional>
+---
+```
+
+Links must be embedded in prose with relationship explanations, not appended as an unstructured list.
+
+### Step 8: Verify
+
+After writing:
+
+- read the written card
+- confirm required frontmatter exists
+- confirm wikilinks are syntactically valid
+- optionally run `memex links <slug>` or `memex doctor` in a later implementation phase
+
+## Frontmatter Serialization Constraint
+
+Current `stringifyFrontmatter` in `src/lib/parser.ts` iterates `Object.entries(data)`, calls `String(value)` on each, and emits bare or single-quoted YAML scalars. It does not handle arrays — an array value becomes its `toString()` representation (e.g. `"a,b,c"`), which `parseFrontmatter` (via `gray-matter`) will read back as a single string, not an array. Round-tripping arrays through write→read is therefore lossy.
+
+**v1 decision: use comma-separated string fields.**
+
+Store experimental metadata as simple string scalars. This is safe with the current serializer and avoids blocking on a parser improvement PR:
+
+```yaml
+context: One sentence summary.
+keywords: 'retrieval, metadata, agentic memory'
+tags: 'memory, workflow, experimental'
+```
+
+Note: `stringifyFrontmatter` single-quotes values that contain commas, so the on-disk representation will use quotes as shown above. The skill must treat these as opaque strings on read (split on `, ` if needed) and must not assume array semantics. A future PR may improve `stringifyFrontmatter` to support YAML sequences, at which point the skill can migrate.
+
+## Testing Strategy
+
+### Config Tests
+
+Add tests in `tests/lib/config.test.ts`:
+
+- reads `experimental.agenticMemory: true`
+- treats false/missing/invalid values as disabled
+- preserves existing config fields
+
+### Skill Tests
+
+If the repo has a skill packaging test, add coverage that the new skill exists and contains the feature flag guard. If not, keep skill validation manual in the first PR.
+
+### Behavior Tests
+
+No core behavior should change when the flag is disabled. Existing tests must pass without updating snapshots for default behavior.
+
+## PR Slicing
+
+### PR 1: PRD and Dev Spec
+
+Files only:
+
+- `docs/superpowers/specs/2026-05-03-agentic-memory-skill-prd.md`
+- `docs/superpowers/specs/2026-05-03-agentic-memory-skill-dev-spec.md`
+
+### PR 2: Feature Flag Parsing
+
+Files:
+
+- `src/lib/config.ts`
+- `tests/lib/config.test.ts`
+- `docs/ARCHITECTURE.md` config section
+
+No behavior change.
+
+### PR 3: Experimental Skill
+
+Files:
+
+- `skills/memex-agentic-memory/SKILL.md`
+- optional plugin packaging references if required
+- docs update describing opt-in behavior
+
+No core command changes.
+
+### PR 4: Retrieval Substrate
+
+Optional and separate from agentic-memory v1. Improve semantic retrieval text to include existing metadata such as title, category, context, keywords, and tags. Treat this as a normal search improvement with its own tests and review; the agentic-memory flag must not be required for it.
+
+### PR 5: Helper Workflow
+
+Optional. Add a read-only helper that returns candidate neighbors for agent review. It must not write links or update cards.
+
+## Multica Harness Plan
+
+Use Multica only for small research and review sprints.
+
+Branch policy:
+
+- Use `agentic-memory-harness` as the shared integration branch.
+- Commit sprint work to that branch instead of opening frequent upstream PRs.
+- Push the branch to the `litaohz/memex` fork so Generator, Evaluator, and Leader can inspect the same history.
+- Open or draft an upstream PR only when Leader recommends a coherent milestone slice.
+
+- Generator: drafts one doc or small patch per sprint.
+- Evaluator: checks for scope creep, missing flag guard, and accidental behavior changes.
+- Leader: summarizes the day's findings and proposes the next small PR.
+
+Sprint constraints:
+
+- max 5 files
+- max 200 changed lines for code PRs
+- docs PRs may exceed 200 lines only when they are the sole change
+- no automatic mutation feature without an accepted design doc
+
+## Resolved Implementation Questions
+
+- **Feature flag check location:** Skill-only in v1. The skill reads `.memexrc` directly via file inspection. A `memex config get` CLI helper is deferred to a later PR.
+- **Metadata storage:** Comma-separated string scalars in frontmatter (see Frontmatter Serialization Constraint above). No body-section workaround needed.
+- **Semantic search and the flag:** Enhanced retrieval is not required for agentic-memory v1. If pursued, it is a separate search improvement with its own tests; the agentic skill may benefit from it but does not own it.
+- **Preview for new cards:** New-card-only writes still produce a preview, but may proceed without extra user confirmation. Updates to existing cards always require preview. This matches FR7/FR8 in the PRD.

--- a/docs/superpowers/specs/2026-05-03-agentic-memory-skill-prd.md
+++ b/docs/superpowers/specs/2026-05-03-agentic-memory-skill-prd.md
@@ -1,0 +1,146 @@
+# PRD: A-MEM-Inspired Agentic Memory Skill
+
+Status: Draft
+Date: 2026-05-03
+Owner: memex contributors
+
+## Summary
+
+Memex already has the core primitives needed for agent memory: create cards, search cards, read cards, write cards, and connect cards with wikilinks. A-MEM is useful because it packages those primitives into a repeatable agentic workflow: create a note, enrich it with semantic metadata, retrieve related memories, decide links, and optionally evolve existing memories.
+
+This product direction should not turn memex into a heavyweight LLM memory engine. Instead, it should add an experimental skill that uses the agent's own reasoning with existing memex tools. The feature should be gated behind a user config flag and default to the current memex behavior.
+
+## Problem
+
+Today, memory quality depends heavily on each agent remembering the right process. A strong agent may create atomic cards, search related cards, add meaningful wikilinks, and update stale cards. A weaker or rushed agent may save isolated notes, miss duplicates, or add no links.
+
+A-MEM shows a useful structure for this process, but its reference implementation assumes a more integrated memory engine with LLM calls inside the memory system. Memex should preserve its simpler architecture: markdown files are the source of truth, and agents perform reasoning outside the core storage layer.
+
+## Goals
+
+- Provide a standard agent workflow for create, metadata enrichment, retrieval, link decisions, and controlled updates.
+- Keep all agentic memory behavior experimental and default-off.
+- Reuse existing memex storage, search, read, write, retro, and wikilink primitives.
+- Avoid adding a mandatory LLM provider or vector database to core memex.
+- Make review easy by shipping small PRs with clear product and technical boundaries.
+
+## Non-Goals
+
+- Do not replace `memex_retro` or existing skills in the first version.
+- Do not automatically mutate existing cards without an explicit preview step.
+- Do not add heuristic auto-linking based only on token overlap or embedding score.
+- Do not add a core LLM orchestration engine to `src/commands` in the first version.
+- Do not change default card behavior for users who do not enable the feature flag.
+
+## Users
+
+Primary users are AI coding agents using memex through CLI, MCP, or bundled skills. The human user benefits from better memory quality without manually curating every card.
+
+Secondary users are maintainers reviewing memex PRs. The feature must be easy to reason about and must not make the core product feel like a different system.
+
+## User Experience
+
+A user opts in through `.memexrc`:
+
+```json
+{
+  "experimental": {
+    "agenticMemory": true
+  }
+}
+```
+
+When enabled, an agent may use the experimental agentic memory skill after meaningful work or when explicitly asked to save knowledge. The skill guides the agent through this flow:
+
+```text
+observe content
+-> draft atomic card
+-> enrich semantic metadata
+-> retrieve candidate neighbors
+-> decide create/update/link/skip
+-> preview proposed memory changes
+-> write through existing memex tools
+```
+
+When disabled, agents continue using the existing recall/retro workflow.
+
+## A-MEM Mapping
+
+A-MEM is inspiration for the workflow, not a requirement to import its architecture. The v1 skill maps the reference system this way:
+
+| A-MEM concept | Memex v1 interpretation |
+|---------------|-------------------------|
+| LLM metadata analysis | Agent drafts `context`, `keywords`, and `tags` before writing |
+| Add note | Agent creates one atomic markdown card through existing memex write paths |
+| Retrieve nearest neighbors | Agent searches existing cards and reads candidates before writing |
+| Strengthen links | Agent adds explicit wikilinks only after reading candidates and explaining relationships |
+| Update neighbor metadata | Agent may propose an update, but existing cards require preview before mutation |
+| Search with linked neighbors | Optional later retrieval improvement, scoped outside agentic-memory v1 |
+
+## Functional Requirements
+
+### FR1: Feature Flag
+
+The experimental workflow must be gated by `.memexrc.experimental.agenticMemory === true`. Default behavior is off.
+
+### FR2: Skill-Based Reasoning
+
+The first version should be implemented as a skill workflow, not as automatic core logic. The skill can use the agent's reasoning to decide card shape, metadata, links, and updates.
+
+### FR3: Atomic Note Creation
+
+The agent must convert raw observations into one or more atomic Zettelkasten cards. Each card should contain one reusable insight, not a transcript or mechanical summary.
+
+### FR4: Metadata Enrichment
+
+The agent should generate metadata candidates such as `keywords`, `context`, and `tags`. For v1 these are stored as comma-separated frontmatter strings; YAML array support is deferred until frontmatter serialization can round-trip arrays safely.
+
+### FR5: Candidate Retrieval
+
+The skill should retrieve related cards before writing. It may use semantic search when configured, and must fall back to keyword search when semantic search is unavailable.
+
+### FR6: Link Decisions
+
+Links must be chosen by the agent after reading candidate cards. Embedding similarity or keyword match is only a candidate signal, not an automatic link decision.
+
+### FR7: Controlled Updates
+
+Updating existing cards is allowed only after a preview. The agent must preserve existing frontmatter and explain why the update is preferable to creating a new card.
+
+### FR8: No Silent Merge
+
+Merge/archive operations are out of scope for the first version unless the user explicitly approves them.
+
+## Acceptance Criteria
+
+- With the flag disabled, the agentic-memory skill does not change existing recall, retro, search, read, or write behavior.
+- With the flag enabled, the skill can guide an agent through create, retrieve, link, and previewed update decisions using existing memex tools.
+- The first implementation PR is reviewable as either docs-only or a small config/skill change.
+- Tests cover feature flag parsing before any runtime behavior depends on it.
+- Documentation clearly explains that A-MEM is inspiration for the workflow, not a replacement for memex architecture.
+
+## Risks
+
+- Scope creep: reviewers may reject a large PR that mixes config, skill, retrieval changes, and write behavior.
+- Over-linking: agents may add weak links if the skill does not require relationship explanations.
+- Metadata drift: new fields may become inconsistent if serialization and update rules are unclear.
+- Hidden mutation: updating existing cards can damage memory quality if not previewed.
+
+## Review Strategy
+
+Iterate on the shared `agentic-memory-harness` branch. Do not open frequent PRs against upstream main for every sprint. Treat PRs as milestone rollups after the branch has a reviewed, coherent slice.
+
+When a PR is warranted, keep it small:
+
+1. PRD and dev spec only.
+2. Feature flag config parsing and tests only.
+3. Experimental skill with default-off guard only.
+4. Optional retrieval substrate improvements.
+5. Optional helper tool or MCP workflow after the skill proves useful.
+
+## Resolved Questions
+
+- **Metadata storage:** Use comma-separated string scalars in frontmatter for v1 (`keywords: a, b, c`). The current `stringifyFrontmatter` cannot round-trip arrays safely. See dev spec for details.
+- **Feature flag exposure:** The skill reads `.memexrc` directly in v1. No CLI command needed yet.
+- **Preview policy:** New-card-only writes still produce a preview, but they do not require extra user confirmation. Updates to existing cards always require preview before mutation (per FR7).
+- **Retrieval substrate scope:** Enhanced retrieval is not part of agentic-memory v1 acceptance. If pursued, ship it as a separate search improvement with its own review and tests.

--- a/skills/memex-agentic-memory/SKILL.md
+++ b/skills/memex-agentic-memory/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: memex-agentic-memory
+description: A-MEM-inspired agentic memory workflow for structured knowledge capture.
+whenToUse: >
+  When experimental.agenticMemory is enabled in .memexrc AND the agent has completed
+  meaningful work that produced reusable insights. This skill provides a structured
+  workflow for creating high-quality atomic memory cards with metadata enrichment,
+  candidate retrieval, and deliberate link decisions. Do NOT use this skill when
+  the feature flag is disabled — fall back to memex-retro instead.
+---
+
+# Agentic Memory Skill (Experimental)
+
+An A-MEM-inspired workflow that uses existing memex primitives to produce
+higher-quality memory cards through structured observation, enrichment,
+retrieval, and deliberate linking.
+
+**This skill is experimental and requires opt-in.**
+
+## Prerequisite: Feature Flag Guard
+
+Before proceeding, locate `.memexrc` using the same precedence as core memex:
+
+1. `$MEMEX_HOME/.memexrc` (if `MEMEX_HOME` env var is set)
+2. Walk up from the current directory looking for `.memexrc`
+3. `~/.memex/.memexrc` (fallback)
+
+Check that `experimental.agenticMemory` is exactly `true`.
+
+**If the flag is missing, false, or not exactly `true`, STOP. Use the standard
+`memex-retro` skill instead.** Do not proceed with the agentic workflow.
+
+## Tools Available
+
+Three equivalent interfaces — use whichever your environment supports:
+
+| CLI (memex in PATH) | Plugin CLI fallback (Claude Code) | MCP tool (VSCode / Cursor) |
+|----------------------|-----------------------------------|----------------------------|
+| `memex search <q>`  | `node ~/.claude/plugins/cache/cc-plugins/memex/*/dist/cli.js search <q>` | `memex_search` with query arg |
+| `memex read <slug>`  | `node ~/.claude/plugins/cache/cc-plugins/memex/*/dist/cli.js read <slug>` | `memex_read` with slug arg |
+| `memex write <slug>` | `node ~/.claude/plugins/cache/cc-plugins/memex/*/dist/cli.js write <slug>` | `memex_write` with slug arg and body |
+
+**Resolution order:** Try `memex` in PATH first. If not found, use the plugin
+fallback or MCP tools.
+
+## Workflow
+
+### Step 1: Input Triage
+
+Identify whether there is a memory-worthy insight from the completed work.
+
+Skip if the content is:
+- Temporary or session-specific (current task state, in-progress work)
+- Obvious or well-known (standard library usage, common patterns)
+- Not reusable across future sessions
+
+If nothing is worth remembering, stop here.
+
+### Step 2: Draft Atomic Card
+
+For each insight, draft one card:
+
+- **Title**: Short, descriptive
+- **Slug**: English kebab-case (e.g., `yaml-array-roundtrip-bug`)
+- **Body**: One atomic insight in your own words. Distill, don't copy.
+- **Context**: Add explicit project/domain context when the insight would be
+  ambiguous without it
+
+### Step 3: Metadata Draft
+
+Generate candidate metadata as simple string fields:
+
+```yaml
+---
+title: <title>
+created: <YYYY-MM-DD>
+source: <client>
+category: <optional>
+context: <one sentence explaining domain and purpose>
+keywords: <3-8 salient terms, comma-separated>
+tags: <broad categories, comma-separated>
+---
+```
+
+**Important**: Store `context`, `keywords`, and `tags` as comma-separated
+strings, not YAML arrays. This avoids frontmatter serialization issues with
+the current `stringifyFrontmatter` implementation.
+
+### Step 4: Candidate Retrieval
+
+Before writing, search for related existing cards.
+
+Try semantic search first:
+
+```bash
+memex search "<topic query>" --semantic --compact --limit 8
+```
+
+If semantic search fails or is unavailable, fall back to keyword search:
+
+```bash
+memex search "<topic query>" --compact --limit 8
+```
+
+Read the top candidates that look relevant:
+
+```bash
+memex read <slug>
+```
+
+**Limits** to avoid runaway retrieval:
+- Max candidate searches: 3
+- Max cards read: 10
+- Max link hops: 2
+
+### Step 5: Decision
+
+Choose exactly one primary action per insight:
+
+| Action | When |
+|--------|------|
+| **create** | No existing card covers the insight. Embed `[[wikilinks]]` in the new card pointing to related candidates when meaningfully related. |
+| **update** | Existing card covers the same insight but lacks new detail |
+| **skip** | Insight is duplicate, too obvious, or not durable |
+
+Rules:
+- **Merge/archive is out of scope** for this version unless the user explicitly asks.
+- Links must be chosen by the agent after reading candidate cards. Embedding
+  similarity or keyword match is only a candidate signal, not an automatic
+  link decision.
+- Updating existing cards is allowed only after preview (Step 6).
+
+### Step 6: Preview
+
+Before writing, produce a preview of planned changes:
+
+```
+Planned memory changes:
+- create: <slug> (<title>)
+- update: <slug> because <reason why update is better than new card>
+- links: [[a]], [[b]] because <relationship explanation>
+- metadata: context/keywords/tags draft
+```
+
+For updates to existing cards, the agent MUST explain why updating is
+preferable to creating a new card.
+
+### Step 7: Write
+
+Use existing memex write paths:
+
+```bash
+memex write <slug> << 'EOF'
+---
+title: <title>
+created: <YYYY-MM-DD>
+source: <client>
+category: <optional>
+context: <one sentence>
+keywords: <comma-separated terms>
+tags: <comma-separated categories>
+---
+
+<One atomic insight in your own words.>
+
+This relates to [[existing-card]] because <explicit relationship explanation>.
+EOF
+```
+
+On update, copy ALL existing frontmatter fields from the current card (title,
+created, source, category, context, keywords, tags, and any custom fields).
+Only modify the specific fields previewed in Step 6. Append new information
+to the body.
+
+### Step 8: Verify
+
+After writing:
+
+```bash
+memex read <slug>
+```
+
+Confirm:
+- Required frontmatter exists (title, created, source)
+- Wikilinks are syntactically valid (`[[slug]]` format)
+- Body contains the intended insight
+
+## Rules
+
+- **Atomic**: One insight per card. Multiple insights = multiple cards.
+- **Own words**: Distill and rephrase. Don't copy-paste.
+- **Links in context**: `[[links]]` must appear in sentences explaining the relationship.
+  - Good: "This contradicts the approach in [[jwt-migration]] — stateless tokens can't be revoked."
+  - Bad: "Related: [[jwt-migration]]"
+- **No auto-linking**: Never add links based solely on keyword overlap or embedding score.
+- **No silent mutation**: Never update an existing card without the preview step.
+- **Preserve frontmatter**: When updating, copy all existing frontmatter fields. Only change fields explicitly previewed.
+- **Metadata as strings**: Use comma-separated strings for keywords/tags, not arrays.
+- **Fallback**: If the feature flag is disabled, use `memex-retro` instead.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,135 @@
+import { readFile, readdir, access } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import type { EmbeddingProviderType } from "./embeddings.js";
+
+export interface MemexConfig {
+  nestedSlugs: boolean;
+  searchDirs?: string[];
+  openaiApiKey?: string;
+  openaiBaseUrl?: string;
+  embeddingModel?: string;
+  /** Embedding provider: "openai" | "azure" | "local" | "ollama". Auto-detected if omitted. */
+  embeddingProvider?: EmbeddingProviderType;
+  /** Azure OpenAI endpoint, e.g. https://resource.openai.azure.com/openai/v1/ */
+  azureOpenaiEndpoint?: string;
+  /** Azure OpenAI API key. Prefer env/key file for local secrets. */
+  azureOpenaiApiKey?: string;
+  /** Path to Azure OpenAI API key file (default: ~/.azure_api_key). */
+  azureOpenaiApiKeyPath?: string;
+  /** Ollama model name (default: "nomic-embed-text"). */
+  ollamaModel?: string;
+  /** Ollama base URL (default: "http://localhost:11434"). */
+  ollamaBaseUrl?: string;
+  /** Local GGUF model path or HuggingFace URI for node-llama-cpp. */
+  localModelPath?: string;
+  /** Extra directories (relative to MEMEX_HOME) whose .md files count as valid link targets in doctor. */
+  extraLinkDirs?: string[];
+  /** Experimental feature flags. */
+  experimental?: {
+    /** Enable A-MEM-inspired agentic memory skill workflow. Default: false. */
+    agenticMemory?: boolean;
+  };
+}
+
+/**
+ * Read config from $MEMEX_HOME/.memexrc
+ * Returns default config if file doesn't exist or is invalid.
+ */
+export async function readConfig(memexHome: string): Promise<MemexConfig> {
+  const configPath = join(memexHome, ".memexrc");
+
+  try {
+    const content = await readFile(configPath, "utf-8");
+    const parsed = JSON.parse(content);
+
+    return {
+      nestedSlugs: parsed.nestedSlugs === true,
+      searchDirs: Array.isArray(parsed.searchDirs) ? parsed.searchDirs : undefined,
+      openaiApiKey: typeof parsed.openaiApiKey === "string" ? parsed.openaiApiKey : undefined,
+      openaiBaseUrl: typeof parsed.openaiBaseUrl === "string" ? parsed.openaiBaseUrl : undefined,
+      embeddingModel: typeof parsed.embeddingModel === "string" ? parsed.embeddingModel : undefined,
+      embeddingProvider: isValidProvider(parsed.embeddingProvider) ? parsed.embeddingProvider : undefined,
+      azureOpenaiEndpoint: typeof parsed.azureOpenaiEndpoint === "string" ? parsed.azureOpenaiEndpoint : undefined,
+      azureOpenaiApiKey: typeof parsed.azureOpenaiApiKey === "string" ? parsed.azureOpenaiApiKey : undefined,
+      azureOpenaiApiKeyPath: typeof parsed.azureOpenaiApiKeyPath === "string" ? parsed.azureOpenaiApiKeyPath : undefined,
+      ollamaModel: typeof parsed.ollamaModel === "string" ? parsed.ollamaModel : undefined,
+      ollamaBaseUrl: typeof parsed.ollamaBaseUrl === "string" ? parsed.ollamaBaseUrl : undefined,
+      localModelPath: typeof parsed.localModelPath === "string" ? parsed.localModelPath : undefined,
+      extraLinkDirs: Array.isArray(parsed.extraLinkDirs) ? parsed.extraLinkDirs : undefined,
+      experimental: parseExperimental(parsed.experimental),
+    };
+  } catch {
+    // File doesn't exist or invalid JSON - return defaults
+    return {
+      nestedSlugs: false,
+    };
+  }
+}
+
+function isValidProvider(value: unknown): value is EmbeddingProviderType {
+  return value === "openai" || value === "azure" || value === "local" || value === "ollama";
+}
+
+function parseExperimental(value: unknown): MemexConfig["experimental"] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const obj = value as Record<string, unknown>;
+  const agenticMemory = obj.agenticMemory === true ? true : undefined;
+  if (agenticMemory === undefined) {
+    return undefined;
+  }
+  return { agenticMemory };
+}
+
+/**
+ * Walk up from `startDir` looking for a `.memexrc` file.
+ * Returns the directory containing the file, or undefined if not found.
+ * Stops at the filesystem root.
+ */
+export async function findMemexrcUp(startDir: string): Promise<string | undefined> {
+  let dir = startDir;
+  for (;;) {
+    try {
+      await access(join(dir, ".memexrc"));
+      return dir;
+    } catch {
+      // not found, keep walking
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the memex home directory.
+ * Precedence: MEMEX_HOME env var > walk-up .memexrc discovery > ~/.memex fallback.
+ */
+export async function resolveMemexHome(): Promise<string> {
+  if (process.env.MEMEX_HOME) {
+    return process.env.MEMEX_HOME;
+  }
+  const found = await findMemexrcUp(process.cwd());
+  if (found) {
+    return found;
+  }
+  return join(homedir(), ".memex");
+}
+
+/**
+ * Warn to stderr if the cards directory doesn't exist or is empty.
+ */
+export async function warnIfEmptyCards(home: string): Promise<void> {
+  const cardsDir = join(home, "cards");
+  try {
+    const entries = await readdir(cardsDir);
+    if (entries.length === 0) {
+      process.stderr.write(`Warning: cards directory is empty (${cardsDir})\n`);
+    }
+  } catch {
+    process.stderr.write(`Warning: cards directory not found (${cardsDir})\n`);
+  }
+}

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readConfig } from "../../src/lib/config.js";
+
+describe("readConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "memex-config-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns default config when file does not exist", async () => {
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  it("returns default config when file is invalid JSON", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), "invalid json{");
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  it("reads nestedSlugs: true from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: true }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: true });
+  });
+
+  it("reads nestedSlugs: false from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  it("treats non-boolean nestedSlugs as false", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: "yes" }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  it("treats missing nestedSlugs field as false", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ otherField: "value" }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  it("reads searchDirs from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: true, searchDirs: ["projects", "notes"] }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: true, searchDirs: ["projects", "notes"] });
+  });
+
+  it("treats non-array searchDirs as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false, searchDirs: "projects" }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false, searchDirs: undefined });
+  });
+
+  it("treats missing searchDirs field as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false }));
+    const config = await readConfig(tmpDir);
+    expect(config).toEqual({ nestedSlugs: false });
+  });
+
+  // --- embeddingProvider config ---
+
+  it("reads embeddingProvider: local from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: "local" }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBe("local");
+  });
+
+  it("reads embeddingProvider: openai from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: "openai" }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBe("openai");
+  });
+
+  it("reads embeddingProvider: ollama from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: "ollama" }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBe("ollama");
+  });
+
+  it("reads embeddingProvider: azure from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: "azure" }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBe("azure");
+  });
+
+  it("treats invalid embeddingProvider as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: "invalid" }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBeUndefined();
+  });
+
+  it("treats non-string embeddingProvider as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ embeddingProvider: 42 }));
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBeUndefined();
+  });
+
+  it("reads ollamaModel from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ ollamaModel: "all-minilm" }));
+    const config = await readConfig(tmpDir);
+    expect(config.ollamaModel).toBe("all-minilm");
+  });
+
+  it("reads ollamaBaseUrl from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ ollamaBaseUrl: "http://myhost:11434" }));
+    const config = await readConfig(tmpDir);
+    expect(config.ollamaBaseUrl).toBe("http://myhost:11434");
+  });
+
+  it("reads Azure OpenAI config from config file", async () => {
+    await writeFile(
+      join(tmpDir, ".memexrc"),
+      JSON.stringify({
+        azureOpenaiEndpoint: "https://example.openai.azure.com/openai/v1/",
+        azureOpenaiApiKey: "azure-test-key",
+        azureOpenaiApiKeyPath: "~/.azure_api_key",
+        embeddingModel: "text-embedding-3-large",
+      })
+    );
+    const config = await readConfig(tmpDir);
+    expect(config.azureOpenaiEndpoint).toBe("https://example.openai.azure.com/openai/v1/");
+    expect(config.azureOpenaiApiKey).toBe("azure-test-key");
+    expect(config.azureOpenaiApiKeyPath).toBe("~/.azure_api_key");
+    expect(config.embeddingModel).toBe("text-embedding-3-large");
+  });
+
+  it("reads localModelPath from config file", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ localModelPath: "/path/to/model.gguf" }));
+    const config = await readConfig(tmpDir);
+    expect(config.localModelPath).toBe("/path/to/model.gguf");
+  });
+
+  it("reads full embedding config together", async () => {
+    await writeFile(
+      join(tmpDir, ".memexrc"),
+      JSON.stringify({
+        nestedSlugs: false,
+        embeddingProvider: "ollama",
+        ollamaModel: "nomic-embed-text",
+        ollamaBaseUrl: "http://localhost:11434",
+        localModelPath: "hf:some/model",
+        openaiApiKey: "sk-test",
+        azureOpenaiEndpoint: "https://example.openai.azure.com/openai/v1/",
+        azureOpenaiApiKeyPath: "~/.azure_api_key",
+      })
+    );
+    const config = await readConfig(tmpDir);
+    expect(config.embeddingProvider).toBe("ollama");
+    expect(config.ollamaModel).toBe("nomic-embed-text");
+    expect(config.ollamaBaseUrl).toBe("http://localhost:11434");
+    expect(config.localModelPath).toBe("hf:some/model");
+    expect(config.openaiApiKey).toBe("sk-test");
+    expect(config.azureOpenaiEndpoint).toBe("https://example.openai.azure.com/openai/v1/");
+    expect(config.azureOpenaiApiKeyPath).toBe("~/.azure_api_key");
+  });
+
+  // --- experimental.agenticMemory config ---
+
+  it("reads experimental.agenticMemory: true", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: { agenticMemory: true } }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toEqual({ agenticMemory: true });
+  });
+
+  it("treats experimental.agenticMemory: false as disabled", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: { agenticMemory: false } }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats missing experimental as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ nestedSlugs: false }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental: null as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: null }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental: string as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: "yes" }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental.agenticMemory: string as disabled", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: { agenticMemory: "true" } }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental.agenticMemory: 1 as disabled", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: { agenticMemory: 1 } }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental: {} (empty object) as undefined", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: {} }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("treats experimental.agenticMemory: null as disabled", async () => {
+    await writeFile(join(tmpDir, ".memexrc"), JSON.stringify({ experimental: { agenticMemory: null } }));
+    const config = await readConfig(tmpDir);
+    expect(config.experimental).toBeUndefined();
+  });
+
+  it("preserves existing config fields alongside experimental", async () => {
+    await writeFile(
+      join(tmpDir, ".memexrc"),
+      JSON.stringify({ nestedSlugs: true, embeddingProvider: "openai", experimental: { agenticMemory: true } })
+    );
+    const config = await readConfig(tmpDir);
+    expect(config.nestedSlugs).toBe(true);
+    expect(config.embeddingProvider).toBe("openai");
+    expect(config.experimental).toEqual({ agenticMemory: true });
+  });
+});


### PR DESCRIPTION
## Summary

Milestone rollup PR for the agentic memory skill (PR1–PR3 slice from the dev spec):

- **PR1 (docs):** PRD and dev spec in `docs/superpowers/specs/`
- **PR2 (feature flag):** Config parsing for `experimental.agenticMemory` in `src/lib/config.ts` with 30 unit tests
- **PR3 (skill):** Experimental `memex-agentic-memory` SKILL.md workflow + architecture docs

### Key design decisions

- Feature is **default-off** behind `.memexrc.experimental.agenticMemory === true`
- No core LLM engine added to `src/commands`
- No automatic mutation of existing cards — all updates require preview
- No heuristic auto-linking — links are agent-decided after reading candidates
- Skill-based reasoning approach: the agent's own reasoning drives the A-MEM workflow using existing memex primitives

### Files changed (6)

| File | Purpose |
|------|---------|
| `docs/superpowers/specs/2026-05-03-agentic-memory-skill-prd.md` | Product requirements |
| `docs/superpowers/specs/2026-05-03-agentic-memory-skill-dev-spec.md` | Technical specification |
| `skills/memex-agentic-memory/SKILL.md` | Experimental skill workflow |
| `src/lib/config.ts` | Feature flag config parsing |
| `tests/lib/config.test.ts` | 30 config tests |
| `docs/ARCHITECTURE.md` | Architecture documentation |

### Testing

- 30 config tests pass (feature flag parsing, backwards compatibility)
- No end-to-end skill workflow test yet (noted as future work)
- Existing test suite unaffected — no default behavior changes

### What's NOT included

- Retrieval substrate improvements (PR4 — future)
- Helper workflow tools (PR5 — future)
- Memory benchmark harness (separate track)