### PR TITLE
feat: enrich semantic embedding text with card metadata

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -735,6 +735,8 @@ export function buildEmbeddingText(raw: string): string {
     const val = data[key];
     if (typeof val === "string" && val.trim()) {
       parts.push(`${key}: ${val.trim()}`);
+    } else if (Array.isArray(val) && val.length > 0) {
+      parts.push(`${key}: ${val.join(", ")}`);
     }
   }
 
@@ -761,10 +763,11 @@ export async function embedCards(
   for (const card of cards) {
     currentSlugs.add(card.slug);
     const raw = await store.readCard(card.slug);
-    const hash = contentHash(raw);
+    const text = buildEmbeddingText(raw);
+    const hash = contentHash(text);
 
     if (cache.needsUpdate(card.slug, hash)) {
-      toEmbed.push({ slug: card.slug, hash, text: buildEmbeddingText(raw) });
+      toEmbed.push({ slug: card.slug, hash, text });
     }
   }
 

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -741,7 +741,7 @@ export function buildEmbeddingText(raw: string): string {
   }
 
   if (parts.length === 0) {
-    return raw;
+    return content;
   }
 
   return parts.join("\n") + "\n\n" + content;

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -6,6 +6,7 @@ import { request as httpRequest } from "node:http";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { CardStore } from "./store.js";
+import { parseFrontmatter } from "./parser.js";
 
 /**
  * Generic embedding provider interface.
@@ -721,6 +722,30 @@ export interface EmbedCardsResult {
 }
 
 /**
+ * Build enriched text for embedding by prepending parsed metadata fields
+ * (title, category, context, keywords, tags) to the card body.
+ * This improves semantic search quality by making metadata visible to the
+ * embedding model without changing card storage.
+ */
+export function buildEmbeddingText(raw: string): string {
+  const { data, content } = parseFrontmatter(raw);
+  const parts: string[] = [];
+
+  for (const key of ["title", "category", "context", "keywords", "tags"] as const) {
+    const val = data[key];
+    if (typeof val === "string" && val.trim()) {
+      parts.push(`${key}: ${val.trim()}`);
+    }
+  }
+
+  if (parts.length === 0) {
+    return raw;
+  }
+
+  return parts.join("\n") + "\n\n" + content;
+}
+
+/**
  * Scan all cards, embed new/changed ones, remove stale cache entries.
  */
 export async function embedCards(
@@ -739,7 +764,7 @@ export async function embedCards(
     const hash = contentHash(raw);
 
     if (cache.needsUpdate(card.slug, hash)) {
-      toEmbed.push({ slug: card.slug, hash, text: raw });
+      toEmbed.push({ slug: card.slug, hash, text: buildEmbeddingText(raw) });
     }
   }
 

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -178,6 +178,23 @@ Some content.`;
     expect(result).toMatch(/^title: Solo Title\n\n/);
     expect(result).toContain("Some content.");
   });
+
+  it("handles array keywords and tags from YAML", () => {
+    const raw = `---
+title: Array Test
+keywords:
+  - foo
+  - bar
+tags:
+  - alpha
+  - beta
+---
+
+Body.`;
+    const result = buildEmbeddingText(raw);
+    expect(result).toContain("keywords: foo, bar");
+    expect(result).toContain("tags: alpha, beta");
+  });
 });
 
 // --- embedCards ---
@@ -285,5 +302,35 @@ describe("embedCards", () => {
     const result = await embedCards(store, provider, cache);
     expect(result.removed).toBe(1);
     expect(cache.get("beta")).toBeUndefined();
+  });
+
+  it("sends enriched text (not raw) to provider and re-embeds when format changes hash", async () => {
+    const cardContent = `---
+title: Enriched Card
+category: testing
+---
+
+Body text.`;
+    await writeFile(join(cardsDir, "enriched.md"), cardContent);
+
+    const store = new CardStore(cardsDir, archiveDir);
+    const cache = new EmbeddingCache(tmpDir, "mock-model");
+    const embeddedTexts: string[][] = [];
+    const spyProvider: EmbeddingProvider = {
+      model: "mock-model",
+      async embed(texts: string[]): Promise<number[][]> {
+        embeddedTexts.push(texts);
+        return texts.map(() => [0.1, 0.2, 0.3]);
+      },
+    };
+
+    await embedCards(store, spyProvider, cache);
+
+    // Provider should have received enriched text with metadata prepended
+    expect(embeddedTexts[0][0]).toContain("title: Enriched Card");
+    expect(embeddedTexts[0][0]).toContain("category: testing");
+    expect(embeddedTexts[0][0]).toContain("Body text.");
+    // Should NOT contain raw YAML delimiters
+    expect(embeddedTexts[0][0]).not.toMatch(/^---/);
   });
 });

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -7,6 +7,7 @@ import {
   cosineSimilarity,
   contentHash,
   embedCards,
+  buildEmbeddingText,
   type EmbeddingProvider,
 } from "../../src/lib/embeddings.js";
 import { CardStore } from "../../src/lib/store.js";
@@ -121,6 +122,61 @@ describe("contentHash", () => {
 
   it("returns different hashes for different content", () => {
     expect(contentHash("a")).not.toBe(contentHash("b"));
+  });
+});
+
+// --- buildEmbeddingText ---
+
+describe("buildEmbeddingText", () => {
+  it("prepends title, category, context, keywords, tags to body", () => {
+    const raw = `---
+title: My Card
+created: 2026-05-04
+source: test
+category: debugging
+context: Fixes a tricky parser bug
+keywords: parser, yaml, frontmatter
+tags: bugfix, core
+---
+
+The actual card body.`;
+    const result = buildEmbeddingText(raw);
+    expect(result).toContain("title: My Card");
+    expect(result).toContain("category: debugging");
+    expect(result).toContain("context: Fixes a tricky parser bug");
+    expect(result).toContain("keywords: parser, yaml, frontmatter");
+    expect(result).toContain("tags: bugfix, core");
+    expect(result).toContain("The actual card body.");
+    // Should NOT include non-metadata fields like created/source
+    expect(result).not.toContain("created:");
+    expect(result).not.toContain("source:");
+  });
+
+  it("returns raw text when no metadata fields are present", () => {
+    const raw = "Just plain text, no frontmatter.";
+    expect(buildEmbeddingText(raw)).toBe(raw);
+  });
+
+  it("returns raw text when frontmatter has no relevant fields", () => {
+    const raw = `---
+created: 2026-05-04
+source: test
+---
+
+Body only.`;
+    expect(buildEmbeddingText(raw)).toBe(raw);
+  });
+
+  it("handles partial metadata (only title)", () => {
+    const raw = `---
+title: Solo Title
+created: 2026-05-04
+---
+
+Some content.`;
+    const result = buildEmbeddingText(raw);
+    expect(result).toMatch(/^title: Solo Title\n\n/);
+    expect(result).toContain("Some content.");
   });
 });
 

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -157,14 +157,16 @@ The actual card body.`;
     expect(buildEmbeddingText(raw)).toBe(raw);
   });
 
-  it("returns raw text when frontmatter has no relevant fields", () => {
+  it("returns parsed body text when frontmatter has no relevant fields", () => {
     const raw = `---
 created: 2026-05-04
 source: test
 ---
 
 Body only.`;
-    expect(buildEmbeddingText(raw)).toBe(raw);
+    const result = buildEmbeddingText(raw);
+    expect(result).toBe("\nBody only.");
+    expect(result).not.toContain("---");
   });
 
   it("handles partial metadata (only title)", () => {


### PR DESCRIPTION
## Summary

Improve semantic search by embedding selected card metadata alongside the card body:

- prepend `title`, `category`, `context`, `keywords`, and `tags` to the text sent to the embedding provider
- hash the enriched embedding text for cache freshness, so metadata-only changes re-embed cards
- support string and YAML-array metadata values when building embedding text
- keep embedding input format consistent by returning parsed body text instead of raw frontmatter when no enrichment metadata is present

This does not change keyword search behavior and is not tied to the agentic-memory feature flag. It only affects `memex search --semantic`.

## Cache impact

Because the embedding cache hash input changes from raw card content to `buildEmbeddingText(raw)`, existing cached embeddings will mismatch once after this PR. The first `memex search --semantic` after upgrade may re-embed all cards for that provider/model. Users on paid OpenAI/Azure embedding APIs should expect a one-time re-embedding cost.

## Test plan

- [x] `npx vitest run tests/lib/embeddings.test.ts tests/commands/search-semantic.test.ts --reporter=verbose`
- [x] `git diff --check`