### PR TITLE
fix(ci): add timeout-minutes and disable fail-fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ env:
 
 jobs:
   test:
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [22, 24]


### PR DESCRIPTION
## Summary
- **timeout-minutes: 15** — prevents runaway jobs. The `local-embeddings` test downloads a 328MB GGUF model and can hang on Windows/Node22 (burned 46 minutes on PR #123).
- **fail-fast: false** — one flaky platform no longer cancels sibling jobs. In PR #107, a macOS failure cancelled 3 other jobs that would have given useful diagnostic signal.

## Context
Identified during CI investigation of PRs #107, #123, #108. Main branch CI is green — these are PR-interaction issues amplified by the default CI config.

## Test plan
- [x] CI will run on this PR itself, validating the workflow syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)