### PR TITLE
fix(ci): upgrade release/publish workflows to actions v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,14 +6,16 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [20, 22]
+        node: [22, 24]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -32,8 +34,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` and `actions/setup-node` from v4 to v5 in release.yml and publish.yml (Node 20 deprecates Jun 2026)
- Align publish.yml test matrix with test.yml: node `[22, 24]` instead of `[20, 22]`
- Add `timeout-minutes: 15` and `fail-fast: false` to publish.yml test job (consistent with test.yml from #141)

## Root cause analysis of #45
The release workflow is functional. Branch protection was loosened in April. The gap (GitHub Release at v0.1.30, npm at 0.1.32) is because v0.1.31/v0.1.32 were manually published without creating GitHub Releases. Next release should use the `workflow_dispatch` trigger.

Relates to #45

## Test plan
- [x] 540 tests pass locally
- [x] CI will validate workflow syntax on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)