### PR TITLE
feat(search): cap empty/broad queries to prevent context window blowup

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -36,6 +36,7 @@ interface SearchOptions {
 interface SearchResult {
   output: string;
   exitCode: number;
+  totalCount?: number;
 }
 
 export async function searchCommand(store: CardStore, query: string | undefined, options: SearchOptions = {}): Promise<SearchResult> {
@@ -80,17 +81,24 @@ export async function searchCommand(store: CardStore, query: string | undefined,
     return semanticSearch(query, allCards, shouldPrefix, options);
   }
 
-  // No query: list all cards
+  // No query: list all cards (with limit)
   if (!query) {
+    const rawLimit = options.limit ?? DEFAULT_LIMIT;
+    const limit = rawLimit < 0 ? DEFAULT_LIMIT : rawLimit;
+    const toProcess = limit > 0 ? allCards.slice(0, limit) : [];
     const items = await Promise.all(
-      allCards.map(async (c) => {
+      toProcess.map(async (c) => {
         const raw = await c.store.readCard(c.slug);
         const { data } = parseFrontmatter(raw);
         const prefixedSlug = shouldPrefix ? `${c.dirPrefix}/${c.slug}` : c.slug;
         return { slug: prefixedSlug, title: String(data.title || c.slug) };
       })
     );
-    return { output: formatCardList(items), exitCode: 0 };
+    let output = formatCardList(items);
+    if (allCards.length > toProcess.length) {
+      output += `\n\n(${toProcess.length} of ${allCards.length} cards shown. Use \`memex search <keyword>\` to narrow results.)`;
+    }
+    return { output, exitCode: 0, totalCount: allCards.length };
   }
 
   // With query: keyword search body only (strip frontmatter before matching)
@@ -250,7 +258,7 @@ async function keywordSearch(
     );
   }
 
-  return { output: results.join(options.compact ? "\n" : "\n\n"), exitCode: 0 };
+  return { output: results.join(options.compact ? "\n" : "\n\n"), exitCode: 0, totalCount: matchedCards.length };
 }
 
 // --- Semantic search ---
@@ -357,7 +365,7 @@ async function semanticSearch(
     );
   }
 
-  return { output: results.join(options.compact ? "\n" : "\n\n"), exitCode: 0 };
+  return { output: results.join(options.compact ? "\n" : "\n\n"), exitCode: 0, totalCount: scored.length };
 }
 
 /** Compute keyword match counts per card slug (same logic as keyword search). */

--- a/src/mcp/operations.ts
+++ b/src/mcp/operations.ts
@@ -20,6 +20,7 @@ export function registerOperations(
   home: string,
   getClientName: () => string,
 ): void {
+  const INDEX_CHAR_LIMIT = 4000;
   // ---- recall ----
   server.registerTool("memex_recall", {
     description: "IMPORTANT: You MUST call this at the START of every new task or conversation, BEFORE doing any work. This retrieves your persistent memory — knowledge cards from previous sessions with [[bidirectional links]]. Returns the keyword index (if exists) or card list. Optionally search by query. Without calling this first, you will miss context from prior sessions and repeat past mistakes.",
@@ -47,11 +48,16 @@ export function registerOperations(
     if (!filter) {
       const indexResult = await readCommand(store, "index");
       if (indexResult.success) {
-        return { content: [{ type: "text" as const, text: indexResult.content! }] };
+        const fullIndex = indexResult.content!;
+        if (fullIndex.length <= INDEX_CHAR_LIMIT) {
+          return { content: [{ type: "text" as const, text: fullIndex }] };
+        }
+        const summary = summarizeIndex(fullIndex, INDEX_CHAR_LIMIT);
+        return { content: [{ type: "text" as const, text: summary }] };
       }
     }
 
-    const listResult = await searchCommand(store, undefined, { filter });
+    const listResult = await searchCommand(store, undefined, { limit: 10, filter });
     return { content: [{ type: "text" as const, text: listResult.output || "No cards yet." }] };
   });
 
@@ -208,4 +214,45 @@ export function registerOperations(
     return { content: [{ type: "text" as const, text }] };
   });
 
+}
+
+function summarizeIndex(indexContent: string, charLimit: number): string {
+  const lines = indexContent.split("\n");
+  const sections: { heading: string; entryCount: number }[] = [];
+  let currentHeading = "";
+  let currentCount = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+)/);
+    if (headingMatch) {
+      if (currentHeading) {
+        sections.push({ heading: currentHeading, entryCount: currentCount });
+      }
+      currentHeading = headingMatch[1];
+      currentCount = 0;
+    } else if (line.match(/^-\s+/) && currentHeading) {
+      currentCount++;
+    }
+  }
+  if (currentHeading) {
+    sections.push({ heading: currentHeading, entryCount: currentCount });
+  }
+
+  const totalEntries = sections.reduce((sum, s) => sum + s.entryCount, 0);
+
+  const truncated = indexContent.slice(0, charLimit);
+  const lastNewline = truncated.lastIndexOf("\n");
+  const cleanTruncated = lastNewline > 0 ? truncated.slice(0, lastNewline) : truncated;
+
+  const sectionSummary = sections
+    .map((s) => `- **${s.heading}**: ${s.entryCount} entries`)
+    .join("\n");
+
+  return (
+    `Index summary (${totalEntries} total entries across ${sections.length} sections):\n` +
+    sectionSummary +
+    `\n\n--- Showing first ${charLimit} chars ---\n\n` +
+    cleanTruncated +
+    `\n\n(Index truncated. Use \`memex search <keyword>\` to find specific cards.)`
+  );
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -55,16 +55,19 @@ export function createMemexServer(store: CardStore, home?: string): McpServer {
     if (home) await autoFetch(home);
   };
 
+  const MCP_MAX_RESULTS = 50;
+
   server.registerTool("memex_search", {
     description: "Low-level search. Prefer memex_recall for task-start workflows.",
     inputSchema: z.object({
       query: z.string().optional().describe("Search keyword. Omit to list all cards."),
-      limit: z.number().optional().describe("Max results (default 10)"),
+      limit: z.number().optional().describe(`Max results (default 10, max ${MCP_MAX_RESULTS})`),
       semantic: z.boolean().optional().describe("Use embedding-based semantic search"),
     }),
   }, async ({ query, limit, semantic }) => {
     const config = home ? await readConfig(home) : undefined;
-    const result = await searchCommand(store, query, { limit, semantic, config, memexHome: home });
+    const clampedLimit = Math.min(limit ?? 10, MCP_MAX_RESULTS);
+    const result = await searchCommand(store, query, { limit: clampedLimit, semantic, config, memexHome: home });
     return { content: [{ type: "text" as const, text: result.output || "No cards found." }] };
   });
 

--- a/tests/commands/search.test.ts
+++ b/tests/commands/search.test.ts
@@ -127,6 +127,32 @@ When JWT revoke fails, use cache as fallback. See [[jwt-migration]].`
     expect(result.output).not.toContain("Links:");
     expect(result.output).not.toContain("JWT migration is about moving from sessions to tokens.");
   });
+
+  it("caps empty-query results at limit and shows truncation message", async () => {
+    const cardsDir = join(tmpDir, "cards");
+    for (let i = 0; i < 15; i++) {
+      await writeFile(
+        join(cardsDir, `card-${i}.md`),
+        `---\ntitle: Card ${i}\n---\nContent ${i}`
+      );
+    }
+    store.invalidateCache();
+    const result = await searchCommand(store, undefined, { limit: 5 });
+    expect(result.output).toContain("5 of ");
+    expect(result.output).toContain("cards shown");
+    expect(result.totalCount).toBe(17); // 2 original + 15 new
+  });
+
+  it("shows no truncation message when all cards fit within limit", async () => {
+    const result = await searchCommand(store, undefined, { limit: 50 });
+    expect(result.output).not.toContain("cards shown");
+    expect(result.totalCount).toBe(2);
+  });
+
+  it("returns totalCount for keyword search", async () => {
+    const result = await searchCommand(store, "JWT");
+    expect(result.totalCount).toBe(2);
+  });
 });
 
 describe("searchCommand with --all flag (multi-directory)", () => {

--- a/tests/mcp/operations.test.ts
+++ b/tests/mcp/operations.test.ts
@@ -108,6 +108,36 @@ describe("High-level operations", () => {
     expect(text).toContain("b");
   });
 
+  it("memex_recall truncates large index and shows summary", async () => {
+    let indexBody = "---\ntitle: Keyword Index\ncreated: 2026-01-01\nsource: organize\n---\n";
+    indexBody += "## Section A\n";
+    for (let i = 0; i < 100; i++) {
+      indexBody += `- [[card-a-${i}]] — description of card a ${i}\n`;
+    }
+    indexBody += "## Section B\n";
+    for (let i = 0; i < 100; i++) {
+      indexBody += `- [[card-b-${i}]] — description of card b ${i}\n`;
+    }
+    await setup({ index: indexBody });
+    const result = await client.callTool({ name: "memex_recall", arguments: {} });
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("Index summary");
+    expect(text).toContain("Section A");
+    expect(text).toContain("Section B");
+    expect(text).toContain("entries");
+    expect(text).toContain("memex search");
+    expect(text.length).toBeLessThan(indexBody.length);
+  });
+
+  it("memex_recall returns small index in full", async () => {
+    const smallIndex = "---\ntitle: Keyword Index\ncreated: 2026-01-01\nsource: organize\n---\n## Topic\n- [[card-a]] — desc";
+    await setup({ index: smallIndex, "card-a": "---\ntitle: A\n---\ncontent" });
+    const result = await client.callTool({ name: "memex_recall", arguments: {} });
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).not.toContain("Index summary");
+    expect(text).toContain("[[card-a]]");
+  });
+
   it("has all expected high-level tools", async () => {
     await setup();
     const { tools } = await client.listTools();

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -134,4 +134,20 @@ describe("MCP server", () => {
     expect(readResult.isError).toBe(true);
   });
 
+  it("memex_search clamps limit to max 50", async () => {
+    const cards: Record<string, string> = {};
+    for (let i = 0; i < 60; i++) {
+      cards[`card-${i}`] = `---\ntitle: Card ${i}\n---\nContent about topic ${i}`;
+    }
+    await setup(cards);
+    const result = await client.callTool({
+      name: "memex_search",
+      arguments: { limit: 100 },
+    });
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    // With 60 cards and limit clamped to 50, should show truncation
+    expect(text).toContain("50 of 60");
+    expect(text).toContain("cards shown");
+  });
+
 });


### PR DESCRIPTION
## Summary
- **Empty query cap**: `searchCommand` with no query now applies `DEFAULT_LIMIT` (10) instead of returning all cards. Appends truncation footer: `(10 of 834 cards shown. Use memex search <keyword> to narrow results.)`
- **MCP limit clamp**: `memex_search` now clamps caller-provided limit to max 50 via `MCP_MAX_RESULTS`
- **Index summarization**: `memex_recall` now summarizes large indexes (>4000 chars) instead of returning them verbatim — shows section heading + entry counts + first 4000 chars + truncation note
- **totalCount**: `SearchResult` now includes `totalCount` so callers know how many results were available

Fixes #57

## Test plan
- [x] 546 tests pass (6 new tests added)
- [x] Search truncation: 15 cards + limit 5 → shows "5 of 17 cards shown"
- [x] No truncation when all fit: 2 cards + limit 50 → no truncation message
- [x] totalCount populated for keyword search
- [x] MCP limit clamp: 60 cards + limit 100 → shows "50 of 60"
- [x] Large index summary: 200 entries → shows section summary + truncated preview
- [x] Small index: returned in full (existing behavior preserved)
- [x] CLI verified: `memex search` → `(10 of 834 cards shown...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)