### PR TITLE
chore: add .gitattributes to auto-collapse dist/ in PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark generated files so GitHub auto-collapses them in PR diffs
+dist/** linguist-generated
+dist/**/*.map linguist-generated


### PR DESCRIPTION
## Summary
- Add `.gitattributes` marking `dist/**` as `linguist-generated`
- GitHub will auto-collapse these files in PR diffs, making reviews much easier
- `dist/cli.js` is 4.7MB and currently drowns every PR diff

## Test plan
- [x] No code changes, only metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)