### PR TITLE
docs: clarify GitLab sync and contribution path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for helping improve Memex. Keep changes small, reviewable, and tied to a real issue.
+
+## Before You Start
+
+- For bug fixes, link the issue and describe the failure mode.
+- For behavior changes, CLI changes, config changes, or sync changes, open a design doc PR in `docs/` first.
+- For docs-only changes, keep the PR limited to the affected docs.
+- AI-assisted contributions are welcome, but the contributor is responsible for reviewing the diff and running tests.
+
+## Local Setup
+
+```bash
+npm install
+npm test
+npm run build
+```
+
+## Pull Requests
+
+- Branch from `main`.
+- Keep one logical change per PR.
+- Add or update tests for code changes.
+- Update docs when user-visible behavior changes.
+- Run `npm run build` when changing runtime code under `src/`, and include generated `dist/` updates.
+- Avoid unrelated formatting, cleanup, or refactors.
+
+## Sync Changes
+
+Sync is intentionally git-native. The normal path should keep working with any valid git remote, including GitHub, GitLab, self-hosted GitLab, and local bare repositories.
+
+See `docs/GITLAB_SYNC.md` before proposing GitLab-specific changes.

--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ That's it — no extra setup needed. The MCP tool descriptions tell your agent w
 
 All clients read and write the same `~/.memex/cards/` directory. Sync across devices with git:
 
-> **Prerequisite:** Auto-create requires [GitHub CLI](https://cli.github.com/) (`gh auth login`). Or pass your own repo URL to skip this.
+> **Prerequisite:** Auto-create requires [GitHub CLI](https://cli.github.com/) (`gh auth login`). Or pass your own git remote URL to skip this, including GitLab and self-hosted GitLab remotes.
 
 ```bash
 memex sync --init                # auto-creates private memex-cards repo on GitHub
-memex sync --init <repo-url>     # or specify your own repo URL (no gh CLI needed)
+memex sync --init <repo-url>     # or specify your own repo URL (no gh/glab CLI needed)
 memex sync on                    # enable auto-sync after every write
 memex sync                       # manual sync
 memex sync off                   # disable auto-sync
 ```
+
+For GitLab, create an empty private repository first, then pass its SSH or HTTPS remote URL. See the [GitLab sync guide](docs/GITLAB_SYNC.md) for examples.
 
 ### Browse your memory
 

--- a/docs/GITLAB_SYNC.md
+++ b/docs/GITLAB_SYNC.md
@@ -1,0 +1,69 @@
+# GitLab Sync
+
+Memex sync is git-native. It already works with GitLab and self-hosted GitLab when you pass a repository URL to `memex sync --init`.
+
+## Quick Start
+
+Create an empty private repository in GitLab, then initialize Memex sync with that remote:
+
+```bash
+memex sync --init git@gitlab.example.com:group/memex-cards.git
+memex sync on
+memex sync
+```
+
+HTTPS remotes work too:
+
+```bash
+memex sync --init https://gitlab.example.com/group/memex-cards.git
+```
+
+GitLab.com uses the same pattern:
+
+```bash
+memex sync --init git@gitlab.com:user/memex-cards.git
+```
+
+## Authentication
+
+Memex does not handle GitLab credentials directly. Git does.
+
+- SSH auth uses your SSH key, SSH agent, or deploy key.
+- HTTPS auth uses your git credential helper or GitLab personal access token.
+- Avoid putting tokens directly in the command line, because shell history may store them.
+
+## GitHub Auto-Create vs GitLab Remotes
+
+Running `memex sync --init` without a URL is a GitHub convenience path. It uses the GitHub CLI (`gh`) to create or reuse a private `memex-cards` repository.
+
+GitLab support does not require the GitLab CLI (`glab`) for normal sync. Create the repository in GitLab first, then pass its git remote URL.
+
+## Supported Remote Forms
+
+`memex sync --init <repo-url>` accepts standard git remote forms:
+
+```bash
+memex sync --init git@gitlab.example.com:group/project.git
+memex sync --init ssh://git@gitlab.example.com/group/project.git
+memex sync --init https://gitlab.example.com/group/project.git
+```
+
+Absolute local paths are also supported for tests and local bare repositories.
+
+## Known Gaps
+
+- Memex does not auto-create GitLab repositories.
+- Memex does not call GitLab APIs.
+- `memex sync --status` reports the generic `git` adapter, not a provider-specific GitLab adapter.
+
+Those are platform integration features, not blockers for GitLab-backed sync.
+
+## Contribution Path
+
+If you want to improve GitLab support, start with one focused PR:
+
+1. Improve docs or examples.
+2. Add tests for GitLab-style remote URL handling.
+3. Propose a design doc before adding GitLab API or `glab` integration.
+
+Keep the base sync path git-native unless there is a clear user-facing reason to add platform-specific behavior.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with small-PR and design-first guidance
- document GitLab and self-hosted GitLab sync via git remote URLs
- clarify README sync setup: GitHub auto-create uses gh, custom remotes need no gh/glab

Refs #96.

## Tests
- npm test -- tests/lib/sync.test.ts tests/commands/sync.test.ts