### PR TITLE
feat(sensitive-input): add AWS, GCP, Stripe, npm secret patterns + expand credential paths

### DIFF
--- a/src/lib/sensitive-input.ts
+++ b/src/lib/sensitive-input.ts
@@ -20,13 +20,17 @@ const PEM_PRIVATE_KEY_BLOCK_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?----
 const JWT_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const BEARER_RE = /\bAuthorization\s*:\s*Bearer\s+([^\s<>'")]{30,})/gi;
 const ENV_ASSIGNMENT_RE = /^\s*(?:export\s+)?([A-Z0-9_]*(?:API|TOKEN|SECRET|PASSWORD|PRIVATE|CREDENTIAL|AUTH|KEY)[A-Z0-9_]*)\s*=\s*([^\n#]+)/gim;
-const SECRET_LOCATOR_RE = /(^|[\s"'`(])(?:~\/\.(?:claude|aws|config|ssh)(?:\/[^\s"'`)]+)?|\.env(?:\.[A-Za-z0-9_-]+)?)(?=$|[\s"'`)])/i;
+const SECRET_LOCATOR_RE = /(^|[\s"'`(])(?:~\/\.(?:claude|aws|config|ssh|netrc|npmrc|docker|kube)(?:\/[^\s"'`)]+)?|\.env(?:\.[A-Za-z0-9_-]+)?)(?=$|[\s"'`)])/i;
 
 const KNOWN_SECRET_RES = [
   /\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b/g,
   /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}\b/g,
   /\bglpat-[A-Za-z0-9_-]{20,}\b/g,
   /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\b[sr]k_(?:live|test)_[A-Za-z0-9]{24,}\b/g,
+  /\bnpm_[A-Za-z0-9]{36}\b/g,
   JWT_RE,
 ];
 

--- a/tests/lib/sensitive-input.test.ts
+++ b/tests/lib/sensitive-input.test.ts
@@ -74,6 +74,47 @@ describe("sensitive input guard", () => {
     expect(text).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
   });
 
+  it("rejects AWS access keys", () => {
+    const result = prepareMemexInput("key is AKIAIOSFODNN7EXAMPLE", "content");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Sensitive input rejected");
+  });
+
+  it("rejects Google Cloud API keys", () => {
+    const result = prepareMemexInput("key AIzaSyA1234567890abcdefghijklmnopqrstuv", "content");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Sensitive input rejected");
+  });
+
+  it("rejects Stripe live/test keys", () => {
+    // Build dynamically to avoid GitHub push protection false positive
+    const fakeKey = "sk" + "_live_" + "a".repeat(30);
+    const result = prepareMemexInput(fakeKey, "query");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Sensitive input rejected");
+  });
+
+  it("rejects npm tokens", () => {
+    const result = prepareMemexInput("npm_abcdefghijklmnopqrstuvwxyz1234567890", "content");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Sensitive input rejected");
+  });
+
+  it("warns on expanded credential paths in queries", () => {
+    for (const path of ["~/.netrc", "~/.npmrc", "~/.docker/config.json", "~/.kube/config"]) {
+      const result = prepareMemexInput(`check ${path} for creds`, "query");
+      expect(result.ok).toBe(true);
+      expect(result.warnings[0]).toContain("local credential path");
+    }
+  });
+
+  it("redacts new secret patterns in display text", () => {
+    const text = redactSensitiveText("aws AKIAIOSFODNN7EXAMPLE and npm_abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(text).not.toContain("npm_abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(text).toContain("<redacted>");
+  });
+
   it("masks flomo webhook URLs", () => {
     expect(maskFlomoWebhookUrl("https://flomoapp.com/iwh/abc/123/")).toBe(
       "https://flomoapp.com/iwh/<redacted>/",


### PR DESCRIPTION
## What

Expand v0.2.0 sensitive-input guardrails with additional secret patterns commonly encountered in developer workflows.

## Changes

### New secret detection patterns (added to `KNOWN_SECRET_RES`)
- **AWS access keys**: `AKIA[0-9A-Z]{16}`
- **Google Cloud API keys**: `AIza[0-9A-Za-z_-]{35}`
- **Stripe live/test keys**: `[sr]k_(live|test)_[A-Za-z0-9]{24,}`
- **npm tokens**: `npm_[A-Za-z0-9]{36}`

### Expanded credential path warnings
`SECRET_LOCATOR_RE` now also matches:
- `~/.netrc` (HTTP auth credentials)
- `~/.npmrc` (npm registry tokens)
- `~/.docker` (registry auth)
- `~/.kube` (cluster credentials)

### Tests
6 new test cases covering all patterns.

## Why

The existing guardrails cover OpenAI, GitHub, GitLab, and Slack tokens. These additions close gaps for the most common cloud provider and package manager credentials. All patterns follow the same reject-on-detect approach used by existing rules.

All 17 sensitive-input tests pass.